### PR TITLE
Added node unit test runner with code coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .*.swp
 npm-debug.log
 .idea
+cover/

--- a/package.json
+++ b/package.json
@@ -1,54 +1,64 @@
 {
-    "name": "package-json-validator",
-    "version": "0.5.6",
-    "description": "Tools to validate package.json files",
-    "author": {
-        "name": "Nick Sullivan",
-        "email": "nick@sullivanflock.com",
-        "web": "http://creationeer.me"
+  "name": "package-json-validator",
+  "version": "0.5.6",
+  "description": "Tools to validate package.json files",
+  "author": {
+    "name": "Nick Sullivan",
+    "email": "nick@sullivanflock.com",
+    "web": "http://creationeer.me"
+  },
+  "contributors": [
+    {
+      "name": "Nick Sullivan",
+      "email": "nick@sullivanflock.com",
+      "url": "http://creationeer.me"
     },
-    "contributors": [
-        {
-            "name": "Nick Sullivan",
-            "email": "nick@sullivanflock.com",
-            "url": "http://creationeer.me"
-        },
-        {
-            "name": "Peter deHaan",
-            "url": "https://github.com/pdehaan"
-        },
-        {
-            "name": "Jatin Chopra",
-            "url": "https://github.com/jatin-"
-        }
-    ],
-    "repository": {
-        "type": "git",
-        "url": "git@github.com:gorillamania/package.json-validator.git"
+    {
+      "name": "Peter deHaan",
+      "url": "https://github.com/pdehaan"
     },
-    "licenses": [{
-        "type": "MIT",
-        "url": "https://github.com/gorillamania/package.json-validator/blob/master/LICENSE"
-    }],
-    "keywords": ["package.json", "validator", "package.json validator", "lint", "package.json linter"],
-    "homepage": "http://package-json-validator.com",
-    "bugs": {
-        "url" : "http://github.com/gorillamania/package.json-validator/issues",
-        "email" : "nick@sullivanflock.com"
-    },
-    "dependencies": {
-        "optimist": "~0.6.0"
-    },
-    "devDependencies": {
-        "grunt": "~0.4.1",
-        "grunt-contrib-jshint": "~0",
-        "grunt-contrib-qunit": "~0"
-    },
-    "scripts": {
-        "test": "grunt citest"
-    },
-    "main": "PJV.js",
-    "bin": {
-        "pjv": "./bin/pjv"
+    {
+      "name": "Jatin Chopra",
+      "url": "https://github.com/jatin-"
     }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:gorillamania/package.json-validator.git"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/gorillamania/package.json-validator/blob/master/LICENSE"
+    }
+  ],
+  "keywords": [
+    "package.json",
+    "validator",
+    "package.json validator",
+    "lint",
+    "package.json linter"
+  ],
+  "homepage": "http://package-json-validator.com",
+  "bugs": {
+    "url": "http://github.com/gorillamania/package.json-validator/issues",
+    "email": "nick@sullivanflock.com"
+  },
+  "dependencies": {
+    "optimist": "~0.6.0"
+  },
+  "devDependencies": {
+    "grunt": "~0.4.1",
+    "grunt-contrib-jshint": "~0",
+    "grunt-contrib-qunit": "~0",
+    "gt": "^0.8.34"
+  },
+  "scripts": {
+    "test": "grunt citest && npm run node-unit-test",
+    "node-unit-test": "node node_modules/gt/gt.js PJV.js test/qunit-pjv.js"
+  },
+  "main": "PJV.js",
+  "bin": {
+    "pjv": "./bin/pjv"
+  }
 }

--- a/test/qunit-pjv.js
+++ b/test/qunit-pjv.js
@@ -1,4 +1,4 @@
-var PJV = window.PJV;
+var PJV = (typeof window !== 'undefined' && window || require('../PJV')).PJV;
 
 function getPackageJson(extra) {
     var out = {
@@ -46,7 +46,7 @@ QUnit.test("Field formats", function() {
     QUnit.equal(PJV.packageFormat.test("_abc123"), false, "starts with underscore");
     QUnit.equal(PJV.validatePeople("people", "Barney Rubble").length, 0, "author string: name");
     QUnit.equal(PJV.validatePeople("people", "Barney Rubble <b@rubble.com> (http://barneyrubble.tumblr.com/)").length, 0, "author string: name, email, url");
-    QUnit.equal(PJV.validatePeople("people", "<b@rubble.com> (http://barneyrubble.tumblr.com/)").length > 0, 1, "author string: name required");
+    QUnit.equal(PJV.validatePeople("people", "<b@rubble.com> (http://barneyrubble.tumblr.com/)").length > 0, true, "author string: name required");
     QUnit.equal(PJV.validate(JSON.stringify(getPackageJson({bin: "./path/to/program"})), "npm").valid, true, "bin: can be string");
     QUnit.equal(PJV.validate(JSON.stringify(getPackageJson({bin: {"my-project": "./path/to/program"}})), "npm").valid, true, "bin: can be object");
     QUnit.equal(PJV.validate(JSON.stringify(getPackageJson({bin: ["./path/to/program"]})), "npm").valid, false, "bin: can't be an array");
@@ -65,6 +65,7 @@ QUnit.test("Dependencies Ranges", function() {
             'caret-top': '^1'
         },
         devDependencies: {
+            'caret-first': '^1.0.0',
             'range': '1.2.3 - 2.3.4',
             'lteq': '<=1.2.3',
             'gteq': '>=1.2.3',


### PR DESCRIPTION
I added node QUnit-compatible runner [gt](https://github.com/bahmutov/gt) (my own package) that provides code coverage via istanbul. It runs under `npm test` command, runs same tests as QUnit in phantomjs instance, but tells overall coverage stats + generates detailed HTML report in cover/lcov-report/index.html.

It would be very easy to send the coverage report to [coveralls.io if needed](http://bahmutov.calepin.co/code-coverage-via-gt-and-coveralls.html)

Here is the CLI info:

![screen shot 2014-03-11 at 10 27 35 pm](https://f.cloud.github.com/assets/2212006/2393327/55b3c92e-a98e-11e3-9a6f-7391502c0f33.png)
