### PR TITLE
Fix man field

### DIFF
--- a/PJV.js
+++ b/PJV.js
@@ -30,7 +30,7 @@
                 "files":        {"type": "array"},
                 "main":         {"type": "string"},
                 "bin":          {"types": ["string", "object"]},
-                "man":          {"type": "object"},
+                "man":          {"types": ["string", "array"]},
                 "directories":  {"type": "object"},
                 "repository":   {"types": ["string", "object"], warning: true, validate: PJV.validateUrlTypes, or: "repositories"},
                 "scripts":      {"type": "object"},


### PR DESCRIPTION
As per the [package.json spec](https://docs.npmjs.com/files/package.json#man), the `man` field can be either:

- A single file path `string` to the manfile or archive
- An `array` of `string`s of multiple file paths

A simple fix to the types for the npm spec.

Closes #62.