### PR TITLE
fix: add bin key back to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
 	],
 	"type": "commonjs",
 	"main": "PJV.js",
+	"bin": {
+		"pjv": "./bin/pjv"
+	},
 	"files": [
 		"bin/",
 		"demo/",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #100
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
   - I just opened this Issue, and then added a PR to address it.
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Re-added the `bin` key to package.json so that `npx package-json-validator` works without having to install the package.

## Output

```
$ npx package-json-validator --warnings --recommendations
{ valid: true }
```