### PR TITLE
fix: add support for catalog:, npm:, and workspace: protocol

### DIFF
--- a/PJV.js
+++ b/PJV.js
@@ -317,6 +317,11 @@
 			v === "" ||
 			v === "latest" ||
 			(v.indexOf && v.indexOf("git") === 0) ||
+			// https://pnpm.io/next/workspaces#workspace-protocol-workspace
+			/^workspace:((\^|~)?[0-9.x]*|(<=?|>=?)?[0-9.x][\-.+\w]+|\*)?$/.test(v) ||
+			// https://pnpm.io/next/catalogs
+			(v.indexOf && v.indexOf("catalog:") === 0) ||
+			(v.indexOf && v.indexOf("npm:") === 0) ||
 			false
 		);
 	};

--- a/PJV.test.mjs
+++ b/PJV.test.mjs
@@ -121,6 +121,16 @@ describe("NPM", () => {
 					"x-version": "1.2.x",
 					"tilde-top": "~1",
 					"caret-top": "^1",
+					"workspace-package-no-range": "workspace:",
+					"workspace-package-caret": "workspace:^",
+					"workspace-package-any": "workspace:*",
+					"workspace-package-tilde-version": "workspace:~1.2.3",
+					"workspace-gt-version": "workspace:>1.2.3",
+					"workspace-pre-release": "workspace:1.2.3-rc.1",
+					"catalog-package": "catalog:",
+					"catalog-named-package": "catalog:react19",
+					"svgo-v1": "npm:svgo@1.3.2",
+					"svgo-v2": "npm:svgo@2.0.3",
 				},
 				devDependencies: {
 					range: "1.2.3 - 2.3.4",
@@ -151,6 +161,10 @@ describe("NPM", () => {
 			const json = getPackageJson({
 				devDependencies: {
 					"package-name": "abc123",
+					"bad-catalog": "catalob:",
+					"bad-workspace": "workspace:abc123",
+					"bad-workspace-range": "workspace:^>1.2.3",
+					"bad-npm": "npm;svgo@^1.2.3",
 				},
 			});
 
@@ -158,6 +172,10 @@ describe("NPM", () => {
 
 			assert.deepStrictEqual(result.errors, [
 				"Invalid version range for dependency package-name: abc123",
+				"Invalid version range for dependency bad-catalog: catalob:",
+				"Invalid version range for dependency bad-workspace: workspace:abc123",
+				"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
+				"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
 			]);
 		});
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues/509 and #71
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds support for pnpm's catalog: protocol as well as yarn and pnpm's workspace protocol. Catalog entries can be simply `catalog:` or include a named catalog record (e.g. `catalog:react19`).  Workspace, can just be `workspace:` or workspace with a range specifier (`workspace:^`) or workspace and a specific version range (`workspace:^1.50`).

Workspace protocol: https://pnpm.io/next/workspaces#workspace-protocol-workspace
Catalog: https://pnpm.io/next/catalogs

Closes #71 (and possible https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues/509)
