### PR TITLE
fix: exclude demo from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,12 +39,7 @@
 		"pjv": "./bin/pjv"
 	},
 	"files": [
-		"bin/",
-		"demo/",
-		"index.html",
-		"LICENSE.md",
-		"package.json",
-		"README.md"
+		"bin/"
 	],
 	"scripts": {
 		"format": "prettier .",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #97 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change removes the demo folder from the package's files, as well as redundant entries for files that npm includes by default (https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files).

Result of `npm pack` following this change:
![Screenshot of a directory containing bin/, README.md, PJV.js, package.json, and LICENSE.md](https://github.com/user-attachments/assets/3bcd14b0-faa2-4939-a67a-d49f84523988)


Closes #97 
