### PR TITLE
chore: add .github/renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"automerge": true,
+	"extends": ["config:best-practices", "replacements:all"],
+	"ignoreDeps": ["codecov/codecov-action"],
+	"labels": ["dependencies"],
+	"minimumReleaseAge": "7 days",
+	"patch": { "enabled": false },
+	"postUpdateOptions": ["pnpmDedupe"]
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #90
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Sets up the Renovate config per my standard templating: ignore patch versions, otherwise extend from the recommended settings, and wait a week on new releases.