### PR TITLE
ci: don't include chore PRs in changelog

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -12,7 +12,19 @@
 	"plugins": {
 		"@release-it/conventional-changelog": {
 			"infile": "CHANGELOG.md",
-			"preset": "angular"
+			"preset": "angular",
+			"types": [
+				{ "section": "Features", "type": "feat" },
+				{ "section": "Bug Fixes", "type": "fix" },
+				{ "section": "Performance Improvements", "type": "perf" },
+				{ "hidden": true, "type": "build" },
+				{ "hidden": true, "type": "chore" },
+				{ "hidden": true, "type": "ci" },
+				{ "hidden": true, "type": "docs" },
+				{ "hidden": true, "type": "refactor" },
+				{ "hidden": true, "type": "style" },
+				{ "hidden": true, "type": "test" }
+			]
 		}
 	}
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

There wasn't an issue for this 😬, but I thought you might want to carry this over from the template update, allowing for cleaner changelog generation https://github.com/JoshuaKGoldberg/create-typescript-app/pull/1810  Happy to also cascade this to eslint-plugin-package-json as well

If not, no worries, I just noticed a ton of chore entries in the last release 😁 
