### PR TITLE
feat: deprecate the PJV name export

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ npm install package-json-validator
 ```
 
 ```js
-import { PJV } from "package-json-validator";
+import { validate } from "package-json-validator";
 
-PJV.validate(/* ... */);
+validate(/* ... */);
 ```
 
 ## API
 
 ```js
-PJV.validate(packageData[([, spec], options)]);
+validate(packageData[([, spec], options)]);
 ```
 
 `spec` is either `npm`, `commonjs_1.0`, or `commonjs_1.1`
@@ -68,15 +68,15 @@ PJV.validate(packageData[([, spec], options)]);
 Example:
 
 ```js
-const { PJV } = require("package-json-validator");
+const { validate } = require("package-json-validator");
 
-PJV.validate(data, spec, options);
+validate(data, spec, options);
 ```
 
 Example1:
 
 ```js
-const { PJV } = require("package-json-validator");
+const { validate } = require("package-json-validator");
 
 const text = JSON.stringify({
 	name: "packageJsonValidator",
@@ -113,7 +113,7 @@ const text = JSON.stringify({
 	},
 });
 
-const data = PJV.validate(text);
+const data = validate(text);
 ```
 
 Output for above example:

--- a/src/PJV.ts
+++ b/src/PJV.ts
@@ -502,8 +502,7 @@ const validateUrlTypes = (
 	return errors;
 };
 
-// TODO: Should we consider deprecating the PJV named export in favor of directly
-// exporting the functions and constants?
+/** @deprecated please use the individual {@link validate} function */
 export const PJV = {
 	// Format regexes
 	emailFormat,
@@ -522,3 +521,5 @@ export const PJV = {
 	validateUrlOrMailto,
 	validateUrlTypes,
 };
+
+export { validate };

--- a/src/bin/pjv.ts
+++ b/src/bin/pjv.ts
@@ -9,7 +9,7 @@ import process from "node:process";
 
 import yargs from "yargs";
 
-import { PJV } from "../PJV.js";
+import { validate } from "../PJV.js";
 import type { SpecName } from "../types";
 
 type Options = {
@@ -59,7 +59,7 @@ if (!fs.existsSync(options.filename)) {
 	process.exitCode = 1;
 } else {
 	const contents = fs.readFileSync(options.filename).toString(),
-		results = PJV.validate(contents, options.spec, {
+		results = validate(contents, options.spec, {
 			warnings: options.warnings,
 			recommendations: options.recommendations,
 		});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { PJV } from "./PJV.js";
+export { PJV, validate } from "./PJV.js";
 export type { SpecName, SpecType } from "./types";


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #124 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change officially deprecates the PJV named export, in favor of directly exporting the `validate` function.

Closes #124