### PR TITLE
feat: add support for object input

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Of course, there are multiple ones to follow, which makes it trickier.
 - [CommonJS Packages 1.0](http://wiki.commonjs.org/wiki/Packages/1.0)
 - [CommonJS Packages 1.1](http://wiki.commonjs.org/wiki/Packages/1.1)
 
-## Usages
+## Usage
 
 ### Command line
 
@@ -65,15 +65,20 @@ validate(packageData[([, spec], options)]);
 }
 ```
 
-Example:
+Example using an object:
 
 ```js
 const { validate } = require("package-json-validator");
 
-validate(data, spec, options);
+const packageData = {
+	name: "my-package",
+	version: "1.2.3",
+};
+
+validate(packageData);
 ```
 
-Example1:
+Example using a string:
 
 ```js
 const { validate } = require("package-json-validator");

--- a/src/PJV.ts
+++ b/src/PJV.ts
@@ -212,11 +212,11 @@ type ValidationOutput = {
 	critical?: string | Record<string, string>;
 };
 const validate = (
-	data: string,
+	data: string | object,
 	specName: SpecName = "npm",
 	options: ValidationOptions = {},
 ): ValidationOutput => {
-	const parsed = parse(data);
+	const parsed = typeof data == "object" ? data : parse(data);
 	const out: ValidationOutput = { valid: false };
 
 	if (typeof parsed == "string") {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #66
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change introduces the ability to pass an object to the validate function in addition to a stringified json object.

I updated the docs and added additional unit tests to verify every form of validation we're already testing but with object input instead of string.

![screenshot of tests passing for new unit tests](https://github.com/user-attachments/assets/e0f2ea34-f246-409b-9852-e20ad01caec2)

**_NOTE:_** As far as the order of things, it would probably be best to land https://github.com/JoshuaKGoldberg/package-json-validator/pull/135 before this one, and then let me update this change to use `validate` directly in the new unit tests before merging this.

Closes #66 
