### PR TITLE
feat(validate): expand errors to include field name

### DIFF
--- a/src/PJV.test.ts
+++ b/src/PJV.test.ts
@@ -132,11 +132,31 @@ describe("PJV", () => {
 				const result = validate(JSON.stringify(json), "npm");
 
 				assert.deepStrictEqual(result.errors, [
-					"Invalid version range for dependency bad-catalog: catalob:",
-					"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
-					"Invalid version range for dependency bad-workspace: workspace:abc123",
-					"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
-					"Invalid version range for dependency package-name: abc123",
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-catalog: catalob:",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-workspace: workspace:abc123",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency package-name: abc123",
+					},
 				]);
 			});
 
@@ -150,7 +170,11 @@ describe("PJV", () => {
 				const result = validate(JSON.stringify(json), "npm");
 
 				assert.deepStrictEqual(result.errors, [
-					"Invalid version range for dependency package-name: abc123",
+					{
+						field: "peerDependencies",
+						message:
+							"Invalid version range for dependency package-name: abc123",
+					},
 				]);
 			});
 
@@ -355,11 +379,31 @@ describe("PJV", () => {
 				const result = validate(json, "npm");
 
 				assert.deepStrictEqual(result.errors, [
-					"Invalid version range for dependency bad-catalog: catalob:",
-					"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
-					"Invalid version range for dependency bad-workspace: workspace:abc123",
-					"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
-					"Invalid version range for dependency package-name: abc123",
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-catalog: catalob:",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-workspace: workspace:abc123",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency package-name: abc123",
+					},
 				]);
 			});
 
@@ -373,7 +417,11 @@ describe("PJV", () => {
 				const result = validate(json, "npm");
 
 				assert.deepStrictEqual(result.errors, [
-					"Invalid version range for dependency package-name: abc123",
+					{
+						field: "peerDependencies",
+						message:
+							"Invalid version range for dependency package-name: abc123",
+					},
 				]);
 			});
 

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -171,11 +171,31 @@ describe("validate", () => {
 				const result = validate(JSON.stringify(json), "npm");
 
 				assert.deepStrictEqual(result.errors, [
-					"Invalid version range for dependency bad-catalog: catalob:",
-					"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
-					"Invalid version range for dependency bad-workspace: workspace:abc123",
-					"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
-					"Invalid version range for dependency package-name: abc123",
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-catalog: catalob:",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-workspace: workspace:abc123",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency package-name: abc123",
+					},
 				]);
 			});
 
@@ -189,7 +209,11 @@ describe("validate", () => {
 				const result = validate(JSON.stringify(json), "npm");
 
 				assert.deepStrictEqual(result.errors, [
-					"Invalid version range for dependency package-name: abc123",
+					{
+						field: "peerDependencies",
+						message:
+							"Invalid version range for dependency package-name: abc123",
+					},
 				]);
 			});
 
@@ -377,7 +401,7 @@ describe("validate", () => {
 				assert.equal(result.critical, undefined, JSON.stringify(result));
 			});
 
-			it("reports a complaint when devDependencies has an invalid range", () => {
+			it("reports errors when devDependencies have invalid ranges", () => {
 				const json = getPackageJson({
 					devDependencies: {
 						"bad-catalog": "catalob:",
@@ -391,11 +415,31 @@ describe("validate", () => {
 				const result = validate(json, "npm");
 
 				assert.deepStrictEqual(result.errors, [
-					"Invalid version range for dependency bad-catalog: catalob:",
-					"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
-					"Invalid version range for dependency bad-workspace: workspace:abc123",
-					"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
-					"Invalid version range for dependency package-name: abc123",
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-catalog: catalob:",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-workspace: workspace:abc123",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
+					},
+					{
+						field: "devDependencies",
+						message:
+							"Invalid version range for dependency package-name: abc123",
+					},
 				]);
 			});
 
@@ -409,7 +453,11 @@ describe("validate", () => {
 				const result = validate(json, "npm");
 
 				assert.deepStrictEqual(result.errors, [
-					"Invalid version range for dependency package-name: abc123",
+					{
+						field: "peerDependencies",
+						message:
+							"Invalid version range for dependency package-name: abc123",
+					},
 				]);
 			});
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #51
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds changes the `errors` array that's returned from `validate` to be an array of objects that includes `field` and `message`, so that each error message is associated with which field the error applies to.

`errors` is now of type `ValidationError[]` where `ValidationError` is
```ts
interface ValidationError {
  field: string;
  message: string;
}
```

Question: is there value in doing similar for `warnings` and `recommendations`?  I'm thinking not, since the presence of those won't make the overall result invalid (whereas `errors` does result in an invalid result), but i'm certainly open to applying the same to those for consistency.

