### PR TITLE
feat(validateBin): add new validateBin function

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,8 @@
 {
 	"extends": "markdownlint/style/prettier",
 	"first-line-h1": false,
+	"no-duplicate-heading": {
+		"siblings_only": true
+	},
 	"no-inline-html": false
 }

--- a/README.md
+++ b/README.md
@@ -49,25 +49,29 @@ validate(/* ... */);
 
 ## API
 
-```js
-validate(packageData[([, spec], options)]);
-```
+### validate(data, spec?, options?)
 
-`spec` is either `npm`, `commonjs_1.0`, or `commonjs_1.1`
+This function validates an entire `package.json` and returns a list of errors, if
+any violations are found.
 
-`options` is an object with the following available:
+#### Parameters
 
-```js
-{
-    warnings: true, // show warnings
-    recommendations: true // show recommendations
-}
-```
+- `data` packageData object or a JSON-stringified version of the package data.
+- `spec` is either `npm`, `commonjs_1.0`, or `commonjs_1.1`
+- `options` is an object with the following:
+  ```ts
+  interface Options {
+  	recommendations?: boolean; // show recommendations
+  	warnings?: boolean; // show warnings
+  }
+  ```
+
+#### Examples
 
 Example using an object:
 
 ```js
-const { validate } = require("package-json-validator");
+import { validate } from "package-json-validator";
 
 const packageData = {
 	name: "my-package",
@@ -80,7 +84,7 @@ validate(packageData);
 Example using a string:
 
 ```js
-const { validate } = require("package-json-validator");
+import { validate } from "package-json-validator";
 
 const text = JSON.stringify({
 	name: "packageJsonValidator",
@@ -140,6 +144,42 @@ console.log(data);
 //    'Missing optional field: engines'
 //  ]
 }
+```
+
+### validateBin(value)
+
+This function validates the value of the `bin` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- It should be of type `string` or `object`.
+- If it's a `string`, it should be a relative path to an executable file.
+- If it's an `object`, it should be a key to string value object, and the values should all be relative paths.
+
+It returns a list of error messages if any violations are found.
+
+#### Examples
+
+```ts
+import { validateBin } from "package-json-validator";
+
+const packageData = {
+	bin: "./my-cli.js",
+};
+
+const errors = validateBin(packageData.bin);
+```
+
+```ts
+import { validateBin } from "package-json-validator";
+
+const packageData = {
+	bin: {
+		"my-cli": "./my-cli.js",
+		"my-dev-cli": "./dev/my-cli.js",
+	},
+};
+
+const errors = validateBin(packageData.bin);
 ```
 
 ## Supported Specifications

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
-export { PJV } from "./PJV.js";
+export { PJV } from "./PJV";
 export type { SpecName, SpecType } from "./types";
-export { validate } from "./validate.js";
+export { validate } from "./validate";
+export { validateBin } from "./validators";

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,13 +1,14 @@
 import type { SpecMap, SpecName } from "./types";
 
-import { packageFormat, urlFormat, versionFormat } from "./formats.js";
+import { packageFormat, urlFormat, versionFormat } from "./formats";
 import {
+	validateBin,
 	validateDependencies,
 	validatePeople,
 	validateType,
 	validateUrlOrMailto,
 	validateUrlTypes,
-} from "./validators/index.js";
+} from "./validators";
 
 const getSpecMap = (
 	specName: SpecName,
@@ -17,7 +18,7 @@ const getSpecMap = (
 		// https://docs.npmjs.com/cli/v9/configuring-npm/package-json
 		return {
 			author: { validate: validatePeople, warning: true },
-			bin: { types: ["string", "object"] },
+			bin: { validate: (_, value) => validateBin(value) },
 			bugs: { validate: validateUrlOrMailto, warning: true },
 			bundledDependencies: { type: "array" },
 			bundleDependencies: { type: "array" },

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,3 +1,4 @@
+export { validateBin } from "./validateBin";
 export { validateDependencies } from "./validateDependencies";
 export { validatePeople } from "./validatePeople";
 export { validateType } from "./validateType";

--- a/src/validators/validateBin.test.ts
+++ b/src/validators/validateBin.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { validateBin } from "./validateBin";
+
+describe("validateBin", () => {
+	it("should return no errors if the bin field is an empty object", () => {
+		const result = validateBin({});
+		expect(result).toEqual([]);
+	});
+
+	it.each(["./cli.js", "cli.js", "./bin/cli.js", "bin/cli.js"])(
+		"should return no errors if the bin field is a valid string: %s",
+		(binPath) => {
+			const result = validateBin(binPath);
+			expect(result).toEqual([]);
+		},
+	);
+
+	it("should return an error if the bin field is an empty string", () => {
+		const result = validateBin("");
+		expect(result).toEqual([
+			"bin field is empty, but should be a relative path",
+		]);
+	});
+
+	it("should return no errors if the bin field is a valid object with all keys having valid strings", () => {
+		const result = validateBin({
+			"my-cli": "cli.js",
+			"my-dev-tool": "./dev-tool.js",
+			"my-other-cli": "bin/cli.js",
+			"my-other-tool": "./tools/other-tool.js",
+		});
+		expect(result).toEqual([]);
+	});
+
+	it("should return errors if the bin field is an object with some keys having invalid paths", () => {
+		const result = validateBin({
+			"my-cli": "./cli.js",
+			"my-dev-tool": "",
+			"my-other-tool": "  ",
+		});
+		expect(result).toEqual([
+			'bin field "my-dev-tool" is empty, but should be a relative path',
+			'bin field "my-other-tool" is empty, but should be a relative path',
+		]);
+	});
+
+	it("should return an error if the bin field is an object with an empty string key", () => {
+		const result = validateBin({
+			"": "./cli.js",
+			"  ": "./dev-tool.js",
+			"    ": "",
+		});
+		expect(result).toEqual([
+			"bin field 0 has an empty key, but should be a valid command name",
+			"bin field 1 has an empty key, but should be a valid command name",
+			"bin field 2 is empty, but should be a relative path",
+			"bin field 2 has an empty key, but should be a valid command name",
+		]);
+	});
+
+	it("should return errors if the bin field is an object with some keys having non-string values", () => {
+		const result = validateBin({
+			"my-cli": "./cli.js",
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			"my-dev-tool": 123 as any,
+		});
+		expect(result).toEqual(['bin field "my-dev-tool" should be a string']);
+	});
+
+	it("should return an error if the bin field is neither a string nor an object", () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const result = validateBin(123 as any);
+		expect(result).toEqual([
+			'Type for field "bin" should be `string` or `object`, not `number`',
+		]);
+	});
+
+	it("should return an error if the bin field is an array", () => {
+		const result = validateBin(["./cli.js"]);
+		expect(result).toEqual([
+			'Type for field "bin" should be `string` or `object`, not `array`',
+		]);
+	});
+
+	it("should return an error if the bin field is null", () => {
+		const result = validateBin(null);
+		expect(result).toEqual([
+			"bin field is `null`, but should be a `string` or an `object`",
+		]);
+	});
+});

--- a/src/validators/validateBin.ts
+++ b/src/validators/validateBin.ts
@@ -1,0 +1,49 @@
+/**
+ * Validate the `bin` field in a package.json, which can either be a string
+ * with the path to the executable, or a Record&lt;string, string&gt; where the
+ * key is the name of the command and the value is the path to the executable.
+ *
+ * {
+ *   "my-cli" : "./cli.js",
+ *   "my-dev-tool" : "./dev-tool.js",
+ * }
+ */
+export const validateBin = (obj: unknown): string[] => {
+	const errors: string[] = [];
+
+	if (typeof obj === "string") {
+		if (obj.trim() === "") {
+			errors.push(`bin field is empty, but should be a relative path`);
+		}
+	} else if (obj && typeof obj === "object" && !Array.isArray(obj)) {
+		let propertyNumber = 0;
+		for (const [key, value] of Object.entries(obj)) {
+			const normalizedKey = key.trim();
+			const fieldName =
+				normalizedKey === "" ? String(propertyNumber) : `"${normalizedKey}"`;
+
+			if (typeof value !== "string") {
+				errors.push(`bin field ${fieldName} should be a string`);
+			} else if (value.trim() === "") {
+				errors.push(
+					`bin field ${fieldName} is empty, but should be a relative path`,
+				);
+			}
+			if (key.trim() === "") {
+				errors.push(
+					`bin field ${fieldName} has an empty key, but should be a valid command name`,
+				);
+			}
+			propertyNumber++;
+		}
+	} else if (obj == null) {
+		errors.push("bin field is `null`, but should be a `string` or an `object`");
+	} else {
+		const valueType = Array.isArray(obj) ? "array" : typeof obj;
+		errors.push(
+			`Type for field "bin" should be \`string\` or \`object\`, not \`${valueType}\``,
+		);
+	}
+
+	return errors;
+};


### PR DESCRIPTION
Recreation of #230 with the breaking change notice removed. 

## PR Checklist

- [x] Addresses an existing open issue: fixes #223
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateBin` function, which checks that the value passed in is valid for assigning to the "bin" property of a `package.json`

Criteria: it's either a non-empty string or a Record<string, string>
with command name to command path.

The `validate` function's validation of `bin` is now stricter than before.

Closes #223

Co-authored-by: @michaelfaith 