### PR TITLE
fix: add extensions to imports

### DIFF
--- a/src/PJV.test.ts
+++ b/src/PJV.test.ts
@@ -1,7 +1,6 @@
 import { assert, describe, it, test } from "vitest";
 
-import { PJV } from "./PJV";
-import { validate } from "./validate";
+import { PJV, validate } from ".";
 
 const getPackageJson = (
 	extra: Record<string, unknown> = {},

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { PJV } from "./PJV";
+export { PJV } from "./PJV.js";
 export type { SpecName, SpecType } from "./types";
-export { validate } from "./validate";
-export { validateAuthor, validateBin } from "./validators";
+export { validate } from "./validate.js";
+export { validateAuthor, validateBin } from "./validators/index.js";

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,6 +1,6 @@
 import type { SpecMap, SpecName } from "./types";
 
-import { packageFormat, urlFormat, versionFormat } from "./formats";
+import { packageFormat, urlFormat, versionFormat } from "./formats.js";
 import {
 	validateAuthor,
 	validateBin,
@@ -9,7 +9,7 @@ import {
 	validateType,
 	validateUrlOrMailto,
 	validateUrlTypes,
-} from "./validators";
+} from "./validators/index.js";
 
 const getSpecMap = (
 	specName: SpecName,

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,7 +1,7 @@
-export { validateAuthor } from "./validateAuthor";
-export { validateBin } from "./validateBin";
-export { validateDependencies } from "./validateDependencies";
-export { validatePeople } from "./validatePeople";
-export { validateType } from "./validateType";
-export { validateUrlOrMailto } from "./validateUrlOrMailto";
-export { validateUrlTypes } from "./validateUrlTypes";
+export { validateAuthor } from "./validateAuthor.js";
+export { validateBin } from "./validateBin.js";
+export { validateDependencies } from "./validateDependencies.js";
+export { validatePeople } from "./validatePeople.js";
+export { validateType } from "./validateType.js";
+export { validateUrlOrMailto } from "./validateUrlOrMailto.js";
+export { validateUrlTypes } from "./validateUrlTypes.js";

--- a/src/validators/validateAuthor.ts
+++ b/src/validators/validateAuthor.ts
@@ -1,4 +1,4 @@
-import { isPerson, validatePeople } from "./validatePeople";
+import { isPerson, validatePeople } from "./validatePeople.js";
 
 /**
  * Validate the `author` field in a package.json, which can either be a person


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #260 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change fixes a regression, where some of the import paths didn't have explicit extensions.  This package hasn't shifted to bundling yet, and still requires explicit extensions (it would be nice if this was something we enforced, to prevent this kind of regression again in the future).
