### PR TITLE
feat: remove support for the legacy commonjs package specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ See `pjv --help` for usage:
 ```plaintext
 Options:
   --filename, -f         package.json file to validate                      [default: "package.json"]
-  --spec, -s             which spec to use - npm|commonjs_1.0|commonjs_1.1  [default: "npm"]
   --warnings, -w         display warnings                                   [default: false]
   --recommendations, -r  display recommendations                            [default: false]
   --quiet, -q            less output                                        [default: false]
@@ -49,7 +48,7 @@ validate(/* ... */);
 
 ## API
 
-### validate(data, spec?, options?)
+### validate(data, options?)
 
 This function validates an entire `package.json` and returns a list of errors, if
 any violations are found.
@@ -57,7 +56,6 @@ any violations are found.
 #### Parameters
 
 - `data` packageData object or a JSON-stringified version of the package data.
-- `spec` is either `npm`, `commonjs_1.0`, or `commonjs_1.1`
 - `options` is an object with the following:
   ```ts
   interface Options {
@@ -241,13 +239,9 @@ const packageData = {
 const errors = validateType(packageData.type);
 ```
 
-## Supported Specifications
+## Specification
 
-Of course, there are multiple ones to follow, which makes it trickier.
-
-- [NPM](https://docs.npmjs.com/cli/configuring-npm/package-json)
-- [CommonJS Packages 1.0](http://wiki.commonjs.org/wiki/Packages/1.0)
-- [CommonJS Packages 1.1](http://wiki.commonjs.org/wiki/Packages/1.1)
+This package uses the `npm` [spec](https://docs.npmjs.com/cli/configuring-npm/package-json) along with additional [supporting documentation from node](https://nodejs.org/api/packages.html), as its source of truth for validation.
 
 ## Development
 

--- a/src/PJV.test.ts
+++ b/src/PJV.test.ts
@@ -103,7 +103,7 @@ describe("PJV", () => {
 						"verion-build": "1.2.3+build2012",
 					},
 				});
-				const result = validate(JSON.stringify(json), "npm", {
+				const result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: false,
 				});
@@ -122,7 +122,7 @@ describe("PJV", () => {
 					},
 				});
 
-				const result = validate(JSON.stringify(json), "npm");
+				const result = validate(JSON.stringify(json));
 
 				assert.deepStrictEqual(result.errors, [
 					{
@@ -160,7 +160,7 @@ describe("PJV", () => {
 					},
 				});
 
-				const result = validate(JSON.stringify(json), "npm");
+				const result = validate(JSON.stringify(json));
 
 				assert.deepStrictEqual(result.errors, [
 					{
@@ -181,7 +181,7 @@ describe("PJV", () => {
 						url: "https://github.com/JoshuaKGoldberg/package-json-validator",
 					},
 				});
-				const result = validate(JSON.stringify(json), "npm", {
+				const result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: false,
 				});
@@ -191,7 +191,7 @@ describe("PJV", () => {
 
 			test("Required fields", () => {
 				let json = getPackageJson();
-				let result = validate(JSON.stringify(json), "npm", {
+				let result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: false,
 				});
@@ -201,7 +201,7 @@ describe("PJV", () => {
 				["name", "version"].forEach((field) => {
 					json = getPackageJson();
 					delete json[field];
-					result = validate(JSON.stringify(json), "npm", {
+					result = validate(JSON.stringify(json), {
 						recommendations: false,
 						warnings: false,
 					});
@@ -212,7 +212,7 @@ describe("PJV", () => {
 					json = getPackageJson();
 					json.private = true;
 					delete json[field];
-					result = validate(JSON.stringify(json), "npm", {
+					result = validate(JSON.stringify(json), {
 						recommendations: false,
 						warnings: false,
 					});
@@ -223,7 +223,7 @@ describe("PJV", () => {
 
 			test("Warning fields", () => {
 				let json = getPackageJson(npmWarningFields);
-				let result = validate(JSON.stringify(json), "npm", {
+				let result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: true,
 				});
@@ -233,7 +233,7 @@ describe("PJV", () => {
 				for (const field in npmWarningFields) {
 					json = getPackageJson(npmWarningFields);
 					delete json[field];
-					result = validate(JSON.stringify(json), "npm", {
+					result = validate(JSON.stringify(json), {
 						recommendations: false,
 						warnings: true,
 					});
@@ -250,7 +250,7 @@ describe("PJV", () => {
 					type: "module",
 				};
 				let json = getPackageJson(recommendedFields);
-				let result = validate(JSON.stringify(json), "npm", {
+				let result = validate(JSON.stringify(json), {
 					recommendations: true,
 					warnings: false,
 				});
@@ -260,7 +260,7 @@ describe("PJV", () => {
 				for (const field in recommendedFields) {
 					json = getPackageJson(recommendedFields);
 					delete json[field];
-					result = validate(JSON.stringify(json), "npm", {
+					result = validate(JSON.stringify(json), {
 						recommendations: true,
 						warnings: false,
 					});
@@ -278,7 +278,7 @@ describe("PJV", () => {
 
 				// licenses as an array
 				let json = getPackageJson(npmWarningFields);
-				let result = validate(JSON.stringify(json), "npm", {
+				let result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: true,
 				});
@@ -290,7 +290,7 @@ describe("PJV", () => {
 				json = getPackageJson(npmWarningFields);
 				delete json.licenses;
 				json.license = "MIT";
-				result = validate(JSON.stringify(json), "npm", {
+				result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: true,
 				});
@@ -301,7 +301,7 @@ describe("PJV", () => {
 				// neither
 				json = getPackageJson(npmWarningFields);
 				delete json.licenses;
-				result = validate(JSON.stringify(json), "npm", {
+				result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: true,
 				});
@@ -351,7 +351,7 @@ describe("PJV", () => {
 						"verion-build": "1.2.3+build2012",
 					},
 				});
-				const result = validate(json, "npm", {
+				const result = validate(json, {
 					recommendations: false,
 					warnings: false,
 				});
@@ -370,7 +370,7 @@ describe("PJV", () => {
 					},
 				});
 
-				const result = validate(json, "npm");
+				const result = validate(json);
 
 				assert.deepStrictEqual(result.errors, [
 					{
@@ -408,7 +408,7 @@ describe("PJV", () => {
 					},
 				});
 
-				const result = validate(json, "npm");
+				const result = validate(json);
 
 				assert.deepStrictEqual(result.errors, [
 					{
@@ -429,7 +429,7 @@ describe("PJV", () => {
 						url: "https://github.com/JoshuaKGoldberg/package-json-validator",
 					},
 				});
-				const result = validate(json, "npm", {
+				const result = validate(json, {
 					recommendations: false,
 					warnings: false,
 				});
@@ -439,7 +439,7 @@ describe("PJV", () => {
 
 			test("Required fields", () => {
 				let json = getPackageJson();
-				let result = validate(json, "npm", {
+				let result = validate(json, {
 					recommendations: false,
 					warnings: false,
 				});
@@ -449,7 +449,7 @@ describe("PJV", () => {
 				["name", "version"].forEach((field) => {
 					json = getPackageJson();
 					delete json[field];
-					result = validate(json, "npm", {
+					result = validate(json, {
 						recommendations: false,
 						warnings: false,
 					});
@@ -460,7 +460,7 @@ describe("PJV", () => {
 					json = getPackageJson();
 					json.private = true;
 					delete json[field];
-					result = validate(json, "npm", {
+					result = validate(json, {
 						recommendations: false,
 						warnings: false,
 					});
@@ -471,7 +471,7 @@ describe("PJV", () => {
 
 			test("Warning fields", () => {
 				let json = getPackageJson(npmWarningFields);
-				let result = validate(json, "npm", {
+				let result = validate(json, {
 					recommendations: false,
 					warnings: true,
 				});
@@ -481,7 +481,7 @@ describe("PJV", () => {
 				for (const field in npmWarningFields) {
 					json = getPackageJson(npmWarningFields);
 					delete json[field];
-					result = validate(json, "npm", {
+					result = validate(json, {
 						recommendations: false,
 						warnings: true,
 					});
@@ -498,7 +498,7 @@ describe("PJV", () => {
 					type: "module",
 				};
 				let json = getPackageJson(recommendedFields);
-				let result = validate(json, "npm", {
+				let result = validate(json, {
 					recommendations: true,
 					warnings: false,
 				});
@@ -508,7 +508,7 @@ describe("PJV", () => {
 				for (const field in recommendedFields) {
 					json = getPackageJson(recommendedFields);
 					delete json[field];
-					result = validate(json, "npm", {
+					result = validate(json, {
 						recommendations: true,
 						warnings: false,
 					});
@@ -526,7 +526,7 @@ describe("PJV", () => {
 
 				// licenses as an array
 				let json = getPackageJson(npmWarningFields);
-				let result = validate(json, "npm", {
+				let result = validate(json, {
 					recommendations: false,
 					warnings: true,
 				});
@@ -538,7 +538,7 @@ describe("PJV", () => {
 				json = getPackageJson(npmWarningFields);
 				delete json.licenses;
 				json.license = "MIT";
-				result = validate(json, "npm", {
+				result = validate(json, {
 					recommendations: false,
 					warnings: true,
 				});
@@ -549,7 +549,7 @@ describe("PJV", () => {
 				// neither
 				json = getPackageJson(npmWarningFields);
 				delete json.licenses;
-				result = validate(json, "npm", {
+				result = validate(json, {
 					recommendations: false,
 					warnings: true,
 				});

--- a/src/bin/pjv.ts
+++ b/src/bin/pjv.ts
@@ -9,15 +9,12 @@ import fs from "node:fs";
 import process from "node:process";
 import yargs from "yargs";
 
-import type { SpecName } from "../types.js";
-
 import { validate } from "../validate.js";
 
 interface Options {
 	filename: string;
 	quiet: boolean;
 	recommendations: boolean;
-	spec: SpecName;
 	warnings: boolean;
 }
 
@@ -27,12 +24,6 @@ const options = yargs(process.argv.slice(2))
 		alias: "f",
 		default: "package.json",
 		description: "package.json file to validate",
-	})
-	.options("spec", {
-		alias: "s",
-		choices: ["npm", "commonjs_1.0", "commonjs_1.1"],
-		default: "npm",
-		description: "spec to use - npm|commonjs_1.0|commonjs_1.1",
 	})
 	.options("warnings", {
 		alias: "w",
@@ -60,7 +51,7 @@ if (!fs.existsSync(options.filename)) {
 	process.exitCode = 1;
 } else {
 	const contents = fs.readFileSync(options.filename).toString(),
-		results = validate(contents, options.spec, {
+		results = validate(contents, {
 			recommendations: options.recommendations,
 			warnings: options.warnings,
 		});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { PJV } from "./PJV.js";
-export { validate, ValidationOptions } from "./validate.js";
+export { validate, type ValidationOptions } from "./validate.js";
 export {
 	validateAuthor,
 	validateBin,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 export { PJV } from "./PJV.js";
-export type { SpecName, SpecType } from "./types.js";
-export { validate } from "./validate.js";
+export { validate, ValidationOptions } from "./validate.js";
 export {
 	validateAuthor,
 	validateBin,

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,6 @@ export interface Person {
 
 export type SpecMap = Record<string, FieldSpec>;
 
-export type SpecName = "commonjs_1.0" | "commonjs_1.1" | "npm";
-
 export type SpecType = "array" | "boolean" | "object" | "string";
 
 export type UrlOrMailTo =

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -39,10 +39,8 @@ describe("validate", () => {
 
 	test("Field formats", () => {
 		assert.equal(
-			validate(
-				JSON.stringify(getPackageJson({ bin: "./path/to/program" })),
-				"npm",
-			).valid,
+			validate(JSON.stringify(getPackageJson({ bin: "./path/to/program" })))
+				.valid,
 			true,
 			"bin: can be string",
 		);
@@ -51,16 +49,13 @@ describe("validate", () => {
 				JSON.stringify(
 					getPackageJson({ bin: { "my-project": "./path/to/program" } }),
 				),
-				"npm",
 			).valid,
 			true,
 			"bin: can be object",
 		);
 		assert.equal(
-			validate(
-				JSON.stringify(getPackageJson({ bin: ["./path/to/program"] })),
-				"npm",
-			).valid,
+			validate(JSON.stringify(getPackageJson({ bin: ["./path/to/program"] })))
+				.valid,
 			false,
 			"bin: can't be an array",
 		);
@@ -69,34 +64,29 @@ describe("validate", () => {
 				JSON.stringify(
 					getPackageJson({ dependencies: { bad: { version: "3.3.3" } } }),
 				),
-				"npm",
 			).valid,
 			false,
 			"version should be a string",
 		);
 		assert.equal(
-			validate(getPackageJson({ bin: "./path/to/program" }), "npm").valid,
+			validate(getPackageJson({ bin: "./path/to/program" })).valid,
 			true,
 			"bin: can be string | with object input",
 		);
 		assert.equal(
-			validate(
-				getPackageJson({ bin: { "my-project": "./path/to/program" } }),
-				"npm",
-			).valid,
+			validate(getPackageJson({ bin: { "my-project": "./path/to/program" } }))
+				.valid,
 			true,
 			"bin: can be object | with object input",
 		);
 		assert.equal(
-			validate(getPackageJson({ bin: ["./path/to/program"] }), "npm").valid,
+			validate(getPackageJson({ bin: ["./path/to/program"] })).valid,
 			false,
 			"bin: can't be an array | with object input",
 		);
 		assert.equal(
-			validate(
-				getPackageJson({ dependencies: { bad: { version: "3.3.3" } } }),
-				"npm",
-			).valid,
+			validate(getPackageJson({ dependencies: { bad: { version: "3.3.3" } } }))
+				.valid,
 			false,
 			"version should be a string | with object input",
 		);
@@ -143,7 +133,7 @@ describe("validate", () => {
 						"verion-build": "1.2.3+build2012",
 					},
 				});
-				const result = validate(JSON.stringify(json), "npm", {
+				const result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: false,
 				});
@@ -162,7 +152,7 @@ describe("validate", () => {
 					},
 				});
 
-				const result = validate(JSON.stringify(json), "npm");
+				const result = validate(JSON.stringify(json));
 
 				assert.deepStrictEqual(result.errors, [
 					{
@@ -200,7 +190,7 @@ describe("validate", () => {
 					},
 				});
 
-				const result = validate(JSON.stringify(json), "npm");
+				const result = validate(JSON.stringify(json));
 
 				assert.deepStrictEqual(result.errors, [
 					{
@@ -221,7 +211,7 @@ describe("validate", () => {
 						url: "https://github.com/JoshuaKGoldberg/package-json-validator",
 					},
 				});
-				const result = validate(JSON.stringify(json), "npm", {
+				const result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: false,
 				});
@@ -232,7 +222,7 @@ describe("validate", () => {
 
 		test("Required fields", () => {
 			let json = getPackageJson();
-			let result = validate(JSON.stringify(json), "npm", {
+			let result = validate(JSON.stringify(json), {
 				recommendations: false,
 				warnings: false,
 			});
@@ -242,7 +232,7 @@ describe("validate", () => {
 			["name", "version"].forEach((field) => {
 				json = getPackageJson();
 				delete json[field];
-				result = validate(JSON.stringify(json), "npm", {
+				result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: false,
 				});
@@ -253,7 +243,7 @@ describe("validate", () => {
 				json = getPackageJson();
 				json.private = true;
 				delete json[field];
-				result = validate(JSON.stringify(json), "npm", {
+				result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: false,
 				});
@@ -264,7 +254,7 @@ describe("validate", () => {
 
 		test("Warning fields", () => {
 			let json = getPackageJson(npmWarningFields);
-			let result = validate(JSON.stringify(json), "npm", {
+			let result = validate(JSON.stringify(json), {
 				recommendations: false,
 				warnings: true,
 			});
@@ -274,7 +264,7 @@ describe("validate", () => {
 			for (const field in npmWarningFields) {
 				json = getPackageJson(npmWarningFields);
 				delete json[field];
-				result = validate(JSON.stringify(json), "npm", {
+				result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: true,
 				});
@@ -291,7 +281,7 @@ describe("validate", () => {
 				type: "module",
 			};
 			let json = getPackageJson(recommendedFields);
-			let result = validate(JSON.stringify(json), "npm", {
+			let result = validate(JSON.stringify(json), {
 				recommendations: true,
 				warnings: false,
 			});
@@ -301,7 +291,7 @@ describe("validate", () => {
 			for (const field in recommendedFields) {
 				json = getPackageJson(recommendedFields);
 				delete json[field];
-				result = validate(JSON.stringify(json), "npm", {
+				result = validate(JSON.stringify(json), {
 					recommendations: true,
 					warnings: false,
 				});
@@ -315,7 +305,7 @@ describe("validate", () => {
 
 			// licenses as an array
 			let json = getPackageJson(npmWarningFields);
-			let result = validate(JSON.stringify(json), "npm", {
+			let result = validate(JSON.stringify(json), {
 				recommendations: false,
 				warnings: true,
 			});
@@ -327,7 +317,7 @@ describe("validate", () => {
 			json = getPackageJson(npmWarningFields);
 			delete json.licenses;
 			json.license = "MIT";
-			result = validate(JSON.stringify(json), "npm", {
+			result = validate(JSON.stringify(json), {
 				recommendations: false,
 				warnings: true,
 			});
@@ -338,7 +328,7 @@ describe("validate", () => {
 			// neither
 			json = getPackageJson(npmWarningFields);
 			delete json.licenses;
-			result = validate(JSON.stringify(json), "npm", {
+			result = validate(JSON.stringify(json), {
 				recommendations: false,
 				warnings: true,
 			});
@@ -388,7 +378,7 @@ describe("validate", () => {
 						"verion-build": "1.2.3+build2012",
 					},
 				});
-				const result = validate(json, "npm", {
+				const result = validate(json, {
 					recommendations: false,
 					warnings: false,
 				});
@@ -407,7 +397,7 @@ describe("validate", () => {
 					},
 				});
 
-				const result = validate(json, "npm");
+				const result = validate(json);
 
 				assert.deepStrictEqual(result.errors, [
 					{
@@ -445,7 +435,7 @@ describe("validate", () => {
 					},
 				});
 
-				const result = validate(json, "npm");
+				const result = validate(json);
 
 				assert.deepStrictEqual(result.errors, [
 					{
@@ -466,7 +456,7 @@ describe("validate", () => {
 						url: "https://github.com/JoshuaKGoldberg/package-json-validator",
 					},
 				});
-				const result = validate(json, "npm", {
+				const result = validate(json, {
 					recommendations: false,
 					warnings: false,
 				});
@@ -477,7 +467,7 @@ describe("validate", () => {
 
 		test("Required fields", () => {
 			let json = getPackageJson();
-			let result = validate(json, "npm", {
+			let result = validate(json, {
 				recommendations: false,
 				warnings: false,
 			});
@@ -487,7 +477,7 @@ describe("validate", () => {
 			["name", "version"].forEach((field) => {
 				json = getPackageJson();
 				delete json[field];
-				result = validate(json, "npm", {
+				result = validate(json, {
 					recommendations: false,
 					warnings: false,
 				});
@@ -498,7 +488,7 @@ describe("validate", () => {
 				json = getPackageJson();
 				json.private = true;
 				delete json[field];
-				result = validate(json, "npm", {
+				result = validate(json, {
 					recommendations: false,
 					warnings: false,
 				});
@@ -509,7 +499,7 @@ describe("validate", () => {
 
 		test("Warning fields", () => {
 			let json = getPackageJson(npmWarningFields);
-			let result = validate(json, "npm", {
+			let result = validate(json, {
 				recommendations: false,
 				warnings: true,
 			});
@@ -519,7 +509,7 @@ describe("validate", () => {
 			for (const field in npmWarningFields) {
 				json = getPackageJson(npmWarningFields);
 				delete json[field];
-				result = validate(json, "npm", {
+				result = validate(json, {
 					recommendations: false,
 					warnings: true,
 				});
@@ -536,7 +526,7 @@ describe("validate", () => {
 				type: "module",
 			};
 			let json = getPackageJson(recommendedFields);
-			let result = validate(json, "npm", {
+			let result = validate(json, {
 				recommendations: true,
 				warnings: false,
 			});
@@ -546,7 +536,7 @@ describe("validate", () => {
 			for (const field in recommendedFields) {
 				json = getPackageJson(recommendedFields);
 				delete json[field];
-				result = validate(json, "npm", {
+				result = validate(json, {
 					recommendations: true,
 					warnings: false,
 				});
@@ -560,7 +550,7 @@ describe("validate", () => {
 
 			// licenses as an array
 			let json = getPackageJson(npmWarningFields);
-			let result = validate(json, "npm", {
+			let result = validate(json, {
 				recommendations: false,
 				warnings: true,
 			});
@@ -572,7 +562,7 @@ describe("validate", () => {
 			json = getPackageJson(npmWarningFields);
 			delete json.licenses;
 			json.license = "MIT";
-			result = validate(json, "npm", {
+			result = validate(json, {
 				recommendations: false,
 				warnings: true,
 			});
@@ -583,7 +573,7 @@ describe("validate", () => {
 			// neither
 			json = getPackageJson(npmWarningFields);
 			delete json.licenses;
-			result = validate(json, "npm", {
+			result = validate(json, {
 				recommendations: false,
 				warnings: true,
 			});

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,4 +1,4 @@
-import type { SpecMap, SpecName } from "./types.js";
+import type { SpecMap } from "./types.js";
 
 import { packageFormat, urlFormat, versionFormat } from "./formats.js";
 import {
@@ -14,166 +14,70 @@ import {
 	validateUrlOrMailto,
 } from "./validators/index.js";
 
-const getSpecMap = (
-	specName: SpecName,
-	isPrivate: boolean,
-): false | SpecMap => {
-	if (specName == "npm") {
-		// https://docs.npmjs.com/cli/v11/configuring-npm/package-json
-		// https://nodejs.org/api/packages.html
-		return {
-			author: { validate: (_, value) => validateAuthor(value), warning: true },
-			bin: { validate: (_, value) => validateBin(value) },
-			bugs: { validate: validateUrlOrMailto, warning: true },
-			bundledDependencies: { type: "array" },
-			bundleDependencies: { type: "array" },
-			config: { type: "object" },
-			contributors: { validate: validatePeople, warning: true },
-			cpu: { type: "array" },
-			dependencies: {
-				recommended: true,
-				type: "object",
-				validate: validateDependencies,
-			},
-			description: { type: "string", warning: true },
-			devDependencies: { type: "object", validate: validateDependencies },
-			directories: { type: "object" },
-			engines: { recommended: true, type: "object" },
-			engineStrict: { type: "boolean" },
-			files: { type: "array" },
-			homepage: { format: urlFormat, recommended: true, type: "string" },
-			keywords: { type: "array", warning: true },
-			license: { type: "string" },
-			licenses: {
-				or: "license",
-				type: "array",
-				validate: validateUrlTypes,
-				warning: true,
-			},
-			main: { type: "string" },
-			man: { types: ["string", "array"] },
-			name: {
-				format: packageFormat,
-				required: !isPrivate,
-				type: "string",
-			},
-			optionalDependencies: {
-				type: "object",
-				validate: validateDependencies,
-			},
-			os: { type: "array" },
-			peerDependencies: {
-				type: "object",
-				validate: validateDependencies,
-			},
-			preferGlobal: { type: "boolean" },
-			private: { type: "boolean" },
-			publishConfig: { type: "object" },
-			repository: {
-				or: "repositories",
-				types: ["string", "object"],
-				validate: validateUrlTypes,
-				warning: true,
-			},
-			scripts: { type: "object" },
-			type: { recommended: true, validate: (_, value) => validateType(value) },
-			version: {
-				format: versionFormat,
-				required: !isPrivate,
-				type: "string",
-			},
-		};
-	} else if (specName == "commonjs_1.0") {
-		// http://wiki.commonjs.org/wiki/Packages/1.0
-		return {
-			bugs: {
-				required: true,
-				type: "string",
-				validate: validateUrlOrMailto,
-			},
-			builtin: { type: "boolean" },
-			checksums: { type: "object" },
-			contributors: {
-				required: true,
-				type: "array",
-				validate: validatePeople,
-			},
-			cpu: { type: "array" },
-			dependencies: {
-				required: true,
-				type: "object",
-				validate: validateDependencies,
-			},
-			description: { required: true, type: "string" },
-			directories: { type: "object" },
-			engine: { type: "array" },
-			homepage: { format: urlFormat, type: "string" },
-
-			implements: { type: "array" },
-			keywords: { required: true, type: "array" },
-			licenses: {
-				required: true,
-				type: "array",
-				validate: validateUrlTypes,
-			},
-			maintainers: {
-				required: true,
-				type: "array",
-				validate: validatePeople,
-			},
-			name: { format: packageFormat, required: true, type: "string" },
-			os: { type: "array" },
-			repositories: {
-				required: true,
-				type: "object",
-				validate: validateUrlTypes,
-			},
-			scripts: { type: "object" },
-			version: { format: versionFormat, required: true, type: "string" },
-		};
-	} else if (specName == "commonjs_1.1") {
-		// http://wiki.commonjs.org/wiki/Packages/1.1
-		return {
-			bugs: {
-				type: "string",
-				validate: validateUrlOrMailto,
-				warning: true,
-			},
-			builtin: { type: "boolean" },
-			checksums: { type: "object" },
-			contributors: { type: "array", validate: validatePeople },
-
-			cpu: { type: "array" },
-			dependencies: { type: "object", validate: validateDependencies },
-			description: { type: "string", warning: true },
-			directories: { required: true, type: "object" },
-			engine: { type: "array" },
-			homepage: { format: urlFormat, type: "string", warning: true },
-			implements: { type: "array" },
-			keywords: { type: "array" },
-			licenses: {
-				type: "array",
-				validate: validateUrlTypes,
-				warning: true,
-			},
-			main: { required: true, type: "string" },
-			maintainers: {
-				type: "array",
-				validate: validatePeople,
-				warning: true,
-			},
-			name: { format: packageFormat, required: true, type: "string" },
-			os: { type: "array" },
-			overlay: { type: "object" },
-			repositories: { type: "array", validate: validateUrlTypes },
-			scripts: { type: "object" },
-			version: { format: versionFormat, required: true, type: "string" },
-		};
-	} else {
-		// Unrecognized spec
-		return false;
-	}
-};
+// https://docs.npmjs.com/cli/configuring-npm/package-json
+// https://nodejs.org/api/packages.html
+const getSpecMap = (isPrivate: boolean): SpecMap => ({
+	author: { validate: (_, value) => validateAuthor(value), warning: true },
+	bin: { validate: (_, value) => validateBin(value) },
+	bugs: { validate: validateUrlOrMailto, warning: true },
+	bundledDependencies: { type: "array" },
+	bundleDependencies: { type: "array" },
+	config: { type: "object" },
+	contributors: { validate: validatePeople, warning: true },
+	cpu: { type: "array" },
+	dependencies: {
+		recommended: true,
+		type: "object",
+		validate: validateDependencies,
+	},
+	description: { type: "string", warning: true },
+	devDependencies: { type: "object", validate: validateDependencies },
+	directories: { type: "object" },
+	engines: { recommended: true, type: "object" },
+	engineStrict: { type: "boolean" },
+	files: { type: "array" },
+	homepage: { format: urlFormat, recommended: true, type: "string" },
+	keywords: { type: "array", warning: true },
+	license: { type: "string" },
+	licenses: {
+		or: "license",
+		type: "array",
+		validate: validateUrlTypes,
+		warning: true,
+	},
+	main: { type: "string" },
+	man: { types: ["string", "array"] },
+	name: {
+		format: packageFormat,
+		required: !isPrivate,
+		type: "string",
+	},
+	optionalDependencies: {
+		type: "object",
+		validate: validateDependencies,
+	},
+	os: { type: "array" },
+	peerDependencies: {
+		type: "object",
+		validate: validateDependencies,
+	},
+	preferGlobal: { type: "boolean" },
+	private: { type: "boolean" },
+	publishConfig: { type: "object" },
+	repository: {
+		or: "repositories",
+		types: ["string", "object"],
+		validate: validateUrlTypes,
+		warning: true,
+	},
+	scripts: { type: "object" },
+	type: { recommended: true, validate: (_, value) => validateType(value) },
+	version: {
+		format: versionFormat,
+		required: !isPrivate,
+		type: "string",
+	},
+});
 
 const parse = (data: string) => {
 	if (typeof data != "string") {
@@ -219,7 +123,6 @@ interface ValidationError {
 }
 export const validate = (
 	data: object | string,
-	specName: SpecName = "npm",
 	options: ValidationOptions = {},
 ): ValidationOutput => {
 	const parsed = typeof data == "object" ? data : parse(data);
@@ -230,11 +133,7 @@ export const validate = (
 		return out;
 	}
 
-	const map = getSpecMap(specName, parsed.private);
-	if (map === false) {
-		out.critical = { "Invalid specification": specName };
-		return out;
-	}
+	const map = getSpecMap(parsed.private);
 	const errors: ValidationError[] = [];
 	const warnings: string[] = [];
 	const recommendations: string[] = [];


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #314 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change removes support for the long-outdated commonjs 1.0 and 1.1 spec, unifying around the npm spec.
