### PR TITLE
fix: remove warning for the `contributors` field

### DIFF
--- a/src/PJV.test.ts
+++ b/src/PJV.test.ts
@@ -13,7 +13,6 @@ const getPackageJson = (
 const npmWarningFields = {
 	author: "Nick Sullivan <nick@sullivanflock.com>",
 	bugs: "http://example.com/bugs",
-	contributors: ["Nick Sullivan <nick@sullivanflock.com>"],
 	description: "This is my description",
 	keywords: ["keyword1", "keyword2", "keyword3"],
 	licenses: [{ type: "MIT", url: "http://example.com/license" }],

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -13,7 +13,6 @@ const getPackageJson = (
 const npmWarningFields = {
 	author: "Nick Sullivan <nick@sullivanflock.com>",
 	bugs: "http://example.com/bugs",
-	contributors: ["Nick Sullivan <nick@sullivanflock.com>"],
 	description: "This is my description",
 	keywords: ["keyword1", "keyword2", "keyword3"],
 	licenses: [{ type: "MIT", url: "http://example.com/license" }],

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -28,7 +28,7 @@ const getSpecMap = (
 			bundledDependencies: { type: "array" },
 			bundleDependencies: { type: "array" },
 			config: { type: "object" },
-			contributors: { validate: validatePeople, warning: true },
+			contributors: { validate: validatePeople },
 			cpu: { type: "array" },
 			dependencies: {
 				recommended: true,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #60 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Remove warning for `contributors` field
