### PR TITLE
feat(validateScripts): add function for validating `scripts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,33 @@ const packageData = {
 const errors = validateBin(packageData.bin);
 ```
 
+### validateScripts(value)
+
+This function validates the value of the `scripts` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- the property is an object
+- its keys are non-empty strings
+- its values are all non-empty strings
+
+It returns a list of error messages, if any violations are found.
+
+#### Examples
+
+```ts
+import { validateScripts } from "package-json-validator";
+
+const packageData = {
+	scripts: {
+		build: "rollup -c",
+		lint: "eslint .",
+		test: "vitest",
+	},
+};
+
+const errors = validateScripts(packageData.scripts);
+```
+
 ### validateType(value)
 
 This function validates the value of the `type` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,6 @@ export { validate } from "./validate.js";
 export {
 	validateAuthor,
 	validateBin,
+	validateScripts,
 	validateType,
 } from "./validators/index.js";

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -10,6 +10,7 @@ import {
 	validateAuthor,
 	validateBin,
 	validateDependencies,
+	validateScripts,
 	validateType,
 	validateUrlOrMailto,
 } from "./validators/index.js";
@@ -75,7 +76,7 @@ const getSpecMap = (
 				validate: validateUrlTypes,
 				warning: true,
 			},
-			scripts: { type: "object" },
+			scripts: { validate: (_, value) => validateScripts(value) },
 			type: { recommended: true, validate: (_, value) => validateType(value) },
 			version: {
 				format: versionFormat,

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,5 +1,6 @@
 export { validateAuthor } from "./validateAuthor.js";
 export { validateBin } from "./validateBin.js";
 export { validateDependencies } from "./validateDependencies.js";
+export { validateScripts } from "./validateScripts.js";
 export { validateType } from "./validateType.js";
 export { validateUrlOrMailto } from "./validateUrlOrMailto.js";

--- a/src/validators/validateScripts.test.ts
+++ b/src/validators/validateScripts.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { validateScripts } from "./validateScripts.js";
+
+describe("validateScripts", () => {
+	it("should return no errors if the scripts field is an empty object", () => {
+		const result = validateScripts({});
+		expect(result).toEqual([]);
+	});
+
+	it("should return no errors if the scripts field is a valid object with all keys having valid strings", () => {
+		const result = validateScripts({
+			build: "rollup -c",
+			lint: "eslint .",
+			test: "vitest",
+		});
+		expect(result).toEqual([]);
+	});
+
+	it("should return errors if the scripts field is an object with some keys having invalid scripts", () => {
+		const result = validateScripts({
+			build: "rollup -c",
+			lint: "",
+			test: "    ",
+		});
+		expect(result).toEqual([
+			'the value of field "lint" is empty, but should be a script command',
+			'the value of field "test" is empty, but should be a script command',
+		]);
+	});
+
+	it("should return an error if the scripts field is an object with an empty string key", () => {
+		const result = validateScripts({
+			"": "rollup -c",
+			"  ": "eslint .",
+			"    ": "",
+		});
+		expect(result).toEqual([
+			"field 0 has an empty key, but should be a script name",
+			"field 1 has an empty key, but should be a script name",
+			"the value of field 2 is empty, but should be a script command",
+			"field 2 has an empty key, but should be a script name",
+		]);
+	});
+
+	it("should return errors if the scripts field is an object with some keys having non-string values", () => {
+		const result = validateScripts({
+			build: "rollup -c",
+			invalid: 123,
+		});
+		expect(result).toEqual(['the value of field "invalid" should be a string']);
+	});
+
+	it("should return an error if the scripts field is neither a string nor an object", () => {
+		const result = validateScripts(123);
+		expect(result).toEqual(["the type should be `object`, not `number`"]);
+	});
+
+	it("should return an error if the scripts field is an array", () => {
+		const result = validateScripts(["rollup -c", "eslint ."]);
+		expect(result).toEqual(["the type should be `object`, not `array`"]);
+	});
+
+	it("should return an error if the scripts field is null", () => {
+		const result = validateScripts(null);
+		expect(result).toEqual(["the field is `null`, but should be an `object`"]);
+	});
+});

--- a/src/validators/validateScripts.ts
+++ b/src/validators/validateScripts.ts
@@ -1,0 +1,37 @@
+/**
+ * Validate the `scripts` field in a package.json. The value of
+ * should be a Record&lt;string, string&gt;
+ */
+export const validateScripts = (obj: unknown): string[] => {
+	const errors: string[] = [];
+
+	if (obj && typeof obj === "object" && !Array.isArray(obj)) {
+		let propertyNumber = 0;
+		for (const [key, value] of Object.entries(obj)) {
+			const normalizedKey = key.trim();
+			const fieldName =
+				normalizedKey === "" ? String(propertyNumber) : `"${normalizedKey}"`;
+
+			if (typeof value !== "string") {
+				errors.push(`the value of field ${fieldName} should be a string`);
+			} else if (value.trim() === "") {
+				errors.push(
+					`the value of field ${fieldName} is empty, but should be a script command`,
+				);
+			}
+			if (key.trim() === "") {
+				errors.push(
+					`field ${fieldName} has an empty key, but should be a script name`,
+				);
+			}
+			propertyNumber++;
+		}
+	} else if (obj === null) {
+		errors.push("the field is `null`, but should be an `object`");
+	} else {
+		const valueType = Array.isArray(obj) ? "array" : typeof obj;
+		errors.push(`the type should be \`object\`, not \`${valueType}\``);
+	}
+
+	return errors;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue 
   - #292 
   - #63
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateScripts` function that validates the value of the "scripts" field of a package.json.  If returns a list of error messages if a violation is found.  Validation of scripts in the monolithic `validate` function has been switched over to use this function as well.  That means the criteria for `scripts` when running `validate` is stricter than it was before.

The new function validates scripts against the following criteria:
- the property is an object
- its keys are non-empty strings
- its values are all non-empty strings
