### PR TITLE
feat(validateBundleDependencies): add function for validating `bundleDependencies`

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,28 @@ const packageData = {
 const errors = validateBin(packageData.bin);
 ```
 
+### validateBundleDependencies(value)
+
+This function validates the value of the `bundleDependencies` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- the property is either an array or a boolean
+- if it's an array, all items should be strings
+
+It returns a list of error messages, if any violations are found.
+
+#### Examples
+
+```ts
+import { validateBundleDependencies } from "package-json-validator";
+
+const packageData = {
+	bundleDependencies: ["renderized", "super-streams"],
+};
+
+const errors = validateBundleDependencies(packageData.packageData);
+```
+
 ### validateScripts(value)
 
 This function validates the value of the `scripts` property of a `package.json`.

--- a/cspell.json
+++ b/cspell.json
@@ -10,5 +10,11 @@
 		"pnpm-lock.yaml",
 		"src/**/*.test.ts"
 	],
-	"words": ["Pilotfish", "react-chartjs-2", "robotstxt.org", "nodenext"]
+	"words": [
+		"Pilotfish",
+		"react-chartjs-2",
+		"robotstxt.org",
+		"nodenext",
+		"renderized"
+	]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { validate } from "./validate.js";
 export {
 	validateAuthor,
 	validateBin,
+	validateBundleDependencies,
 	validateScripts,
 	validateType,
 } from "./validators/index.js";

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -9,6 +9,7 @@ import {
 import {
 	validateAuthor,
 	validateBin,
+	validateBundleDependencies,
 	validateDependencies,
 	validateScripts,
 	validateType,
@@ -26,8 +27,12 @@ const getSpecMap = (
 			author: { validate: (_, value) => validateAuthor(value), warning: true },
 			bin: { validate: (_, value) => validateBin(value) },
 			bugs: { validate: validateUrlOrMailto, warning: true },
-			bundledDependencies: { type: "array" },
-			bundleDependencies: { type: "array" },
+			bundledDependencies: {
+				validate: (_, value) => validateBundleDependencies(value),
+			},
+			bundleDependencies: {
+				validate: (_, value) => validateBundleDependencies(value),
+			},
 			config: { type: "object" },
 			contributors: { validate: validatePeople },
 			cpu: { type: "array" },

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,5 +1,6 @@
 export { validateAuthor } from "./validateAuthor.js";
 export { validateBin } from "./validateBin.js";
+export { validateBundleDependencies } from "./validateBundleDependencies.js";
 export { validateDependencies } from "./validateDependencies.js";
 export { validateScripts } from "./validateScripts.js";
 export { validateType } from "./validateType.js";

--- a/src/validators/validateBundleDependencies.test.ts
+++ b/src/validators/validateBundleDependencies.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { validateBundleDependencies } from "./validateBundleDependencies.js";
+
+describe("validateBundleDependencies", () => {
+	it("should return no errors if the value is an empty array", () => {
+		const result = validateBundleDependencies([]);
+		expect(result).toEqual([]);
+	});
+
+	it("should return no errors if the value is a valid array with all strings", () => {
+		const result = validateBundleDependencies(["nin", "thee-silver-mt-zion"]);
+		expect(result).toEqual([]);
+	});
+
+	it("should return no errors if the value is a boolean", () => {
+		let result = validateBundleDependencies(true);
+		expect(result).toEqual([]);
+
+		result = validateBundleDependencies(false);
+		expect(result).toEqual([]);
+	});
+
+	it("should return errors if the value is an array with some non-string values", () => {
+		const result = validateBundleDependencies([
+			"nin",
+			null,
+			"thee-silver-mt-zion",
+			123,
+		]);
+		expect(result).toEqual([
+			"item at index 1 should be a string, not `null`",
+			"item at index 3 should be a string, not `number`",
+		]);
+	});
+
+	it("should return an error if the value is an array with non-empty strings", () => {
+		const result = validateBundleDependencies([
+			"",
+			"nin",
+			"",
+			"thee-silver-mt-zion",
+		]);
+		expect(result).toEqual([
+			"item at index 0 is empty, but should be a dependency name",
+			"item at index 2 is empty, but should be a dependency name",
+		]);
+	});
+
+	it("should return an error if the value is a number", () => {
+		const result = validateBundleDependencies(123);
+		expect(result).toEqual([
+			"the type should be `Array` or `boolean`, not `number`",
+		]);
+	});
+
+	it("should return an error if the value is an object", () => {
+		const result = validateBundleDependencies({});
+		expect(result).toEqual([
+			"the type should be `Array` or `boolean`, not `object`",
+		]);
+	});
+
+	it("should return an error if the value is null", () => {
+		const result = validateBundleDependencies(null);
+		expect(result).toEqual([
+			"the field is `null`, but should be an `Array` or a `boolean`",
+		]);
+	});
+});

--- a/src/validators/validateBundleDependencies.ts
+++ b/src/validators/validateBundleDependencies.ts
@@ -1,0 +1,37 @@
+/**
+ * Validate the `bundleDependencies` field in a package.json, which can either be
+ * an array of strings or a boolean.
+ *
+ * ["renderized", "super-streams"]
+ */
+export const validateBundleDependencies = (obj: unknown): string[] => {
+	const errors: string[] = [];
+
+	if (typeof obj === "boolean") {
+		return []; // No errors for boolean, as per spec
+	} else if (Array.isArray(obj)) {
+		// If it's an array, check if all items are non-empty strings
+		for (let i = 0; i < obj.length; i++) {
+			const item = obj[i];
+			if (typeof item !== "string") {
+				const itemType = item === null ? "null" : typeof item;
+				errors.push(
+					`item at index ${i} should be a string, not \`${itemType}\``,
+				);
+			} else if (item.trim() === "") {
+				errors.push(
+					`item at index ${i} is empty, but should be a dependency name`,
+				);
+			}
+		}
+	} else if (obj == null) {
+		errors.push("the field is `null`, but should be an `Array` or a `boolean`");
+	} else {
+		const valueType = typeof obj;
+		errors.push(
+			`the type should be \`Array\` or \`boolean\`, not \`${valueType}\``,
+		);
+	}
+
+	return errors;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #232 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateBundleDependencies` function that validates the value of the "bundleDependencies" field of a package.json. If returns a list of error messages if a violation is found. Validation of bundleDependencies in the monolithic validate function has been switched over to use this function as well. That means the criteria for bundleDependencies when running validate is stricter than it was before.

The new function validates scripts against the following criteria:

- the property is either an array or a boolean
- if it's an array, all items should be strings

Previously, it only validated that the type was an array.
