### PR TITLE
feat: deprecate support for legacy commonjs specifications 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ See `pjv --help` for usage:
 ```plaintext
 Options:
   --filename, -f         package.json file to validate                      [default: "package.json"]
-  --spec, -s             which spec to use - npm|commonjs_1.0|commonjs_1.1  [default: "npm"]
   --warnings, -w         display warnings                                   [default: false]
   --recommendations, -r  display recommendations                            [default: false]
   --quiet, -q            less output                                        [default: false]
@@ -49,7 +48,7 @@ validate(/* ... */);
 
 ## API
 
-### validate(data, spec?, options?)
+### validate(data, options?)
 
 This function validates an entire `package.json` and returns a list of errors, if
 any violations are found.
@@ -57,7 +56,6 @@ any violations are found.
 #### Parameters
 
 - `data` packageData object or a JSON-stringified version of the package data.
-- `spec` is either `npm`, `commonjs_1.0`, or `commonjs_1.1`
 - `options` is an object with the following:
   ```ts
   interface Options {
@@ -268,13 +266,9 @@ const packageData = {
 const errors = validateType(packageData.type);
 ```
 
-## Supported Specifications
+## Specification
 
-Of course, there are multiple ones to follow, which makes it trickier.
-
-- [NPM](https://docs.npmjs.com/cli/configuring-npm/package-json)
-- [CommonJS Packages 1.0](http://wiki.commonjs.org/wiki/Packages/1.0)
-- [CommonJS Packages 1.1](http://wiki.commonjs.org/wiki/Packages/1.1)
+This package uses the `npm` [spec](https://docs.npmjs.com/cli/configuring-npm/package-json) along with additional [supporting documentation from node](https://nodejs.org/api/packages.html), as its source of truth for validation.
 
 ## Development
 

--- a/src/bin/pjv.ts
+++ b/src/bin/pjv.ts
@@ -32,6 +32,7 @@ const options = yargs(process.argv.slice(2))
 		alias: "s",
 		choices: ["npm", "commonjs_1.0", "commonjs_1.1"],
 		default: "npm",
+		deprecated: true,
 		description: "spec to use - npm|commonjs_1.0|commonjs_1.1",
 	})
 	.options("warnings", {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface Person {
 
 export type SpecMap = Record<string, FieldSpec>;
 
+/** @deprecated commonjs_1.0 and commonjs_1.1 specs have been deprecated */
 export type SpecName = "commonjs_1.0" | "commonjs_1.1" | "npm";
 
 export type SpecType = "array" | "boolean" | "object" | "string";

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -38,10 +38,8 @@ describe("validate", () => {
 
 	test("Field formats", () => {
 		assert.equal(
-			validate(
-				JSON.stringify(getPackageJson({ bin: "./path/to/program" })),
-				"npm",
-			).valid,
+			validate(JSON.stringify(getPackageJson({ bin: "./path/to/program" })))
+				.valid,
 			true,
 			"bin: can be string",
 		);
@@ -50,16 +48,13 @@ describe("validate", () => {
 				JSON.stringify(
 					getPackageJson({ bin: { "my-project": "./path/to/program" } }),
 				),
-				"npm",
 			).valid,
 			true,
 			"bin: can be object",
 		);
 		assert.equal(
-			validate(
-				JSON.stringify(getPackageJson({ bin: ["./path/to/program"] })),
-				"npm",
-			).valid,
+			validate(JSON.stringify(getPackageJson({ bin: ["./path/to/program"] })))
+				.valid,
 			false,
 			"bin: can't be an array",
 		);
@@ -68,34 +63,29 @@ describe("validate", () => {
 				JSON.stringify(
 					getPackageJson({ dependencies: { bad: { version: "3.3.3" } } }),
 				),
-				"npm",
 			).valid,
 			false,
 			"version should be a string",
 		);
 		assert.equal(
-			validate(getPackageJson({ bin: "./path/to/program" }), "npm").valid,
+			validate(getPackageJson({ bin: "./path/to/program" })).valid,
 			true,
 			"bin: can be string | with object input",
 		);
 		assert.equal(
-			validate(
-				getPackageJson({ bin: { "my-project": "./path/to/program" } }),
-				"npm",
-			).valid,
+			validate(getPackageJson({ bin: { "my-project": "./path/to/program" } }))
+				.valid,
 			true,
 			"bin: can be object | with object input",
 		);
 		assert.equal(
-			validate(getPackageJson({ bin: ["./path/to/program"] }), "npm").valid,
+			validate(getPackageJson({ bin: ["./path/to/program"] })).valid,
 			false,
 			"bin: can't be an array | with object input",
 		);
 		assert.equal(
-			validate(
-				getPackageJson({ dependencies: { bad: { version: "3.3.3" } } }),
-				"npm",
-			).valid,
+			validate(getPackageJson({ dependencies: { bad: { version: "3.3.3" } } }))
+				.valid,
 			false,
 			"version should be a string | with object input",
 		);
@@ -142,7 +132,7 @@ describe("validate", () => {
 						"verion-build": "1.2.3+build2012",
 					},
 				});
-				const result = validate(JSON.stringify(json), "npm", {
+				const result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: false,
 				});
@@ -161,7 +151,7 @@ describe("validate", () => {
 					},
 				});
 
-				const result = validate(JSON.stringify(json), "npm");
+				const result = validate(JSON.stringify(json));
 
 				assert.deepStrictEqual(result.errors, [
 					{
@@ -199,7 +189,7 @@ describe("validate", () => {
 					},
 				});
 
-				const result = validate(JSON.stringify(json), "npm");
+				const result = validate(JSON.stringify(json));
 
 				assert.deepStrictEqual(result.errors, [
 					{
@@ -220,7 +210,7 @@ describe("validate", () => {
 						url: "https://github.com/JoshuaKGoldberg/package-json-validator",
 					},
 				});
-				const result = validate(JSON.stringify(json), "npm", {
+				const result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: false,
 				});
@@ -231,7 +221,7 @@ describe("validate", () => {
 
 		test("Required fields", () => {
 			let json = getPackageJson();
-			let result = validate(JSON.stringify(json), "npm", {
+			let result = validate(JSON.stringify(json), {
 				recommendations: false,
 				warnings: false,
 			});
@@ -241,7 +231,7 @@ describe("validate", () => {
 			["name", "version"].forEach((field) => {
 				json = getPackageJson();
 				delete json[field];
-				result = validate(JSON.stringify(json), "npm", {
+				result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: false,
 				});
@@ -252,7 +242,7 @@ describe("validate", () => {
 				json = getPackageJson();
 				json.private = true;
 				delete json[field];
-				result = validate(JSON.stringify(json), "npm", {
+				result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: false,
 				});
@@ -263,7 +253,7 @@ describe("validate", () => {
 
 		test("Warning fields", () => {
 			let json = getPackageJson(npmWarningFields);
-			let result = validate(JSON.stringify(json), "npm", {
+			let result = validate(JSON.stringify(json), {
 				recommendations: false,
 				warnings: true,
 			});
@@ -273,7 +263,7 @@ describe("validate", () => {
 			for (const field in npmWarningFields) {
 				json = getPackageJson(npmWarningFields);
 				delete json[field];
-				result = validate(JSON.stringify(json), "npm", {
+				result = validate(JSON.stringify(json), {
 					recommendations: false,
 					warnings: true,
 				});
@@ -290,7 +280,7 @@ describe("validate", () => {
 				type: "module",
 			};
 			let json = getPackageJson(recommendedFields);
-			let result = validate(JSON.stringify(json), "npm", {
+			let result = validate(JSON.stringify(json), {
 				recommendations: true,
 				warnings: false,
 			});
@@ -300,7 +290,7 @@ describe("validate", () => {
 			for (const field in recommendedFields) {
 				json = getPackageJson(recommendedFields);
 				delete json[field];
-				result = validate(JSON.stringify(json), "npm", {
+				result = validate(JSON.stringify(json), {
 					recommendations: true,
 					warnings: false,
 				});
@@ -314,7 +304,7 @@ describe("validate", () => {
 
 			// licenses as an array
 			let json = getPackageJson(npmWarningFields);
-			let result = validate(JSON.stringify(json), "npm", {
+			let result = validate(JSON.stringify(json), {
 				recommendations: false,
 				warnings: true,
 			});
@@ -326,7 +316,7 @@ describe("validate", () => {
 			json = getPackageJson(npmWarningFields);
 			delete json.licenses;
 			json.license = "MIT";
-			result = validate(JSON.stringify(json), "npm", {
+			result = validate(JSON.stringify(json), {
 				recommendations: false,
 				warnings: true,
 			});
@@ -337,7 +327,7 @@ describe("validate", () => {
 			// neither
 			json = getPackageJson(npmWarningFields);
 			delete json.licenses;
-			result = validate(JSON.stringify(json), "npm", {
+			result = validate(JSON.stringify(json), {
 				recommendations: false,
 				warnings: true,
 			});
@@ -387,7 +377,7 @@ describe("validate", () => {
 						"verion-build": "1.2.3+build2012",
 					},
 				});
-				const result = validate(json, "npm", {
+				const result = validate(json, {
 					recommendations: false,
 					warnings: false,
 				});
@@ -406,7 +396,7 @@ describe("validate", () => {
 					},
 				});
 
-				const result = validate(json, "npm");
+				const result = validate(json);
 
 				assert.deepStrictEqual(result.errors, [
 					{
@@ -444,7 +434,7 @@ describe("validate", () => {
 					},
 				});
 
-				const result = validate(json, "npm");
+				const result = validate(json);
 
 				assert.deepStrictEqual(result.errors, [
 					{
@@ -465,7 +455,7 @@ describe("validate", () => {
 						url: "https://github.com/JoshuaKGoldberg/package-json-validator",
 					},
 				});
-				const result = validate(json, "npm", {
+				const result = validate(json, {
 					recommendations: false,
 					warnings: false,
 				});
@@ -476,7 +466,7 @@ describe("validate", () => {
 
 		test("Required fields", () => {
 			let json = getPackageJson();
-			let result = validate(json, "npm", {
+			let result = validate(json, {
 				recommendations: false,
 				warnings: false,
 			});
@@ -486,7 +476,7 @@ describe("validate", () => {
 			["name", "version"].forEach((field) => {
 				json = getPackageJson();
 				delete json[field];
-				result = validate(json, "npm", {
+				result = validate(json, {
 					recommendations: false,
 					warnings: false,
 				});
@@ -497,7 +487,7 @@ describe("validate", () => {
 				json = getPackageJson();
 				json.private = true;
 				delete json[field];
-				result = validate(json, "npm", {
+				result = validate(json, {
 					recommendations: false,
 					warnings: false,
 				});
@@ -508,7 +498,7 @@ describe("validate", () => {
 
 		test("Warning fields", () => {
 			let json = getPackageJson(npmWarningFields);
-			let result = validate(json, "npm", {
+			let result = validate(json, {
 				recommendations: false,
 				warnings: true,
 			});
@@ -518,7 +508,7 @@ describe("validate", () => {
 			for (const field in npmWarningFields) {
 				json = getPackageJson(npmWarningFields);
 				delete json[field];
-				result = validate(json, "npm", {
+				result = validate(json, {
 					recommendations: false,
 					warnings: true,
 				});
@@ -535,7 +525,7 @@ describe("validate", () => {
 				type: "module",
 			};
 			let json = getPackageJson(recommendedFields);
-			let result = validate(json, "npm", {
+			let result = validate(json, {
 				recommendations: true,
 				warnings: false,
 			});
@@ -545,7 +535,7 @@ describe("validate", () => {
 			for (const field in recommendedFields) {
 				json = getPackageJson(recommendedFields);
 				delete json[field];
-				result = validate(json, "npm", {
+				result = validate(json, {
 					recommendations: true,
 					warnings: false,
 				});
@@ -559,7 +549,7 @@ describe("validate", () => {
 
 			// licenses as an array
 			let json = getPackageJson(npmWarningFields);
-			let result = validate(json, "npm", {
+			let result = validate(json, {
 				recommendations: false,
 				warnings: true,
 			});
@@ -571,7 +561,7 @@ describe("validate", () => {
 			json = getPackageJson(npmWarningFields);
 			delete json.licenses;
 			json.license = "MIT";
-			result = validate(json, "npm", {
+			result = validate(json, {
 				recommendations: false,
 				warnings: true,
 			});
@@ -582,7 +572,7 @@ describe("validate", () => {
 			// neither
 			json = getPackageJson(npmWarningFields);
 			delete json.licenses;
-			result = validate(json, "npm", {
+			result = validate(json, {
 				recommendations: false,
 				warnings: true,
 			});

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -206,7 +206,7 @@ const parse = (data: string) => {
 export interface ValidateFunction {
 	(data: object | string, options?: ValidationOptions): ValidationOutput;
 
-	/** @deprecated Both common_js specs have been deprecated. Please use `validate(data, options)` instead. */
+	/** @deprecated Both commonjs specs have been deprecated. Please use `validate(data, options)` instead. */
 	(
 		data: object | string,
 		specName?: SpecName,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #282 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change officially deprecates support for the `commonjs_1.0` and `commonjs_1.1` specs in both the js api and cli.  The NPM spec will be the only supported spec.

Per our deprecation policy, following this release of this deprecation, the api is subject to be removed after 6 months.

Please begin using the `validate(data, options?)`  form of the JS API.
