### PR TITLE
chore: add rfc issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,3 +1,11 @@
+name: 🐛 Bug
+description: Report a bug trying to run the code
+
+title: "🐛 Bug: <short description of the bug>"
+
+labels:
+  - "type: bug"
+
 body:
   - attributes:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
@@ -26,12 +34,3 @@ body:
       description: Any additional info you'd like to provide.
       label: Additional Info
     type: textarea
-
-description: Report a bug trying to run the code
-
-labels:
-  - "type: bug"
-
-name: 🐛 Bug
-
-title: "🐛 Bug: <short description of the bug>"

--- a/.github/ISSUE_TEMPLATE/02-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/02-documentation.yml
@@ -1,3 +1,11 @@
+name: 📝 Documentation
+description: Report a typo or missing area of documentation
+
+title: "📝 Documentation: <short description of the request>"
+
+labels:
+  - "area: documentation"
+
 body:
   - attributes:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
@@ -18,12 +26,3 @@ body:
       description: Any additional info you'd like to provide.
       label: Additional Info
     type: textarea
-
-description: Report a typo or missing area of documentation
-
-labels:
-  - "area: documentation"
-
-name: 📝 Documentation
-
-title: "📝 Documentation: <short description of the request>"

--- a/.github/ISSUE_TEMPLATE/04-rfc.yml
+++ b/.github/ISSUE_TEMPLATE/04-rfc.yml
@@ -15,13 +15,13 @@ body:
           required: true
     type: checkboxes
   - attributes:
-      description: Please provide details about your proposal?
+      description: Please provide details about your proposal.
       label: Overview
     type: textarea
     validations:
       required: true
   - attributes:
-      description: How long should this RFC remain open for feedback?  This should be no less than 6 weeks from the publishing date.
+      description: How long should this RFC remain open for feedback? This should be no less than 6 weeks from the publishing date.
       label: This RFC will remain open until
       placeholder: YYYY-MM-DD
     type: input

--- a/.github/ISSUE_TEMPLATE/04-rfc.yml
+++ b/.github/ISSUE_TEMPLATE/04-rfc.yml
@@ -1,28 +1,27 @@
-name: 🚀 Feature
-description: Request that a new feature be added or an existing feature improved
+name: 💬 RFC
+description: Request feedback from the community on a significant change to the project.
 
-title: "🚀 Feature: <short description of the feature>"
+title: "💬 RFC: <short description of the proposal>"
 
 labels:
-  - "type: feature"
+  - "type: rfc"
 
 body:
   - attributes:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
-      label: Feature Request Checklist
+      label: RFC Checklist
       options:
-        - label: I have pulled the latest `main` branch of the repository.
-          required: true
         - label: I have [searched for related issues](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aissue) and found none that matched my issue.
           required: true
     type: checkboxes
   - attributes:
-      description: What did you expect to be able to do?
+      description: Please provide details about your proposal?
       label: Overview
     type: textarea
     validations:
       required: true
   - attributes:
-      description: Any additional info you'd like to provide.
-      label: Additional Info
-    type: textarea
+      description: How long should this RFC remain open for feedback?  This should be no less than 6 weeks from the publishing date.
+      label: This RFC will remain open until
+      placeholder: YYYY-MM-DD
+    type: input

--- a/.github/ISSUE_TEMPLATE/05-tooling.yml
+++ b/.github/ISSUE_TEMPLATE/05-tooling.yml
@@ -1,3 +1,11 @@
+name: 🛠 Tooling
+description: Report a bug or request an enhancement in repository tooling
+
+title: "🛠 Tooling: <short description of the change>"
+
+labels:
+  - "area: tooling"
+
 body:
   - attributes:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
@@ -20,12 +28,3 @@ body:
       description: Any additional info you'd like to provide.
       label: Additional Info
     type: textarea
-
-description: Report a bug or request an enhancement in repository tooling
-
-labels:
-  - "area: tooling"
-
-name: 🛠 Tooling
-
-title: "🛠 Tooling: <short description of the change>"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -107,10 +107,6 @@ export default tseslint.config(
 		files: ["**/*.{yml,yaml}"],
 		rules: {
 			"yml/file-extension": ["error", { extension: "yml" }],
-			"yml/sort-keys": [
-				"error",
-				{ order: { type: "asc" }, pathPattern: "^.*$" },
-			],
 			"yml/sort-sequence-values": [
 				"error",
 				{ order: { type: "asc" }, pathPattern: "^.*$" },


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #323
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

One of the expectations defined in our Deprecation Policy (https://github.com/JoshuaKGoldberg/package-json-validator/pull/321) is that there should be an RFC period for any proposed API deprecations.  This template will allow user's to create such RFC issues more easily.

Related: https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/pull/1142
