### PR TITLE
feat(validateConfig): add function for validating `config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,29 @@ const packageData = {
 const errors = validateBundleDependencies(packageData.packageData);
 ```
 
+### validateConfig(value)
+
+This function validates the value of the `config` property of a `package.json`.
+It takes the value, and validates that it's an object.
+
+It returns a list of error messages, if a violation is found.
+
+#### Examples
+
+```ts
+import { validateConfig } from "package-json-validator";
+
+const packageData = {
+	config: {
+		debug: true,
+		host: "localhost",
+		port: 8080,
+	},
+};
+
+const errors = validateScripts(packageData.config);
+```
+
 ### validateScripts(value)
 
 This function validates the value of the `scripts` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export {
 	validateAuthor,
 	validateBin,
 	validateBundleDependencies,
+	validateConfig,
 	validateScripts,
 	validateType,
 } from "./validators/index.js";

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -10,6 +10,7 @@ import {
 	validateAuthor,
 	validateBin,
 	validateBundleDependencies,
+	validateConfig,
 	validateDependencies,
 	validateScripts,
 	validateType,
@@ -33,7 +34,7 @@ const getSpecMap = (
 			bundleDependencies: {
 				validate: (_, value) => validateBundleDependencies(value),
 			},
-			config: { type: "object" },
+			config: { validate: (_, value) => validateConfig(value) },
 			contributors: { validate: validatePeople },
 			cpu: { type: "array" },
 			dependencies: {

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,6 +1,7 @@
 export { validateAuthor } from "./validateAuthor.js";
 export { validateBin } from "./validateBin.js";
 export { validateBundleDependencies } from "./validateBundleDependencies.js";
+export { validateConfig } from "./validateConfig.js";
 export { validateDependencies } from "./validateDependencies.js";
 export { validateScripts } from "./validateScripts.js";
 export { validateType } from "./validateType.js";

--- a/src/validators/validateConfig.test.ts
+++ b/src/validators/validateConfig.test.ts
@@ -26,4 +26,9 @@ describe("validateConfig", () => {
 		const result = validateConfig(null);
 		expect(result).toEqual(["the field is `null`, but should be an `object`"]);
 	});
+
+	it("should return an error if the field is a string", () => {
+		const result = validateConfig("string");
+		expect(result).toEqual(["the type should be `object`, not `string`"]);
+	});
 });

--- a/src/validators/validateConfig.test.ts
+++ b/src/validators/validateConfig.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { validateConfig } from "./validateConfig.ts";
+
+describe("validateConfig", () => {
+	it("should return no errors if the field is an empty object", () => {
+		const result = validateConfig({});
+		expect(result).toEqual([]);
+	});
+
+	it("should return no errors if the field is an object", () => {
+		const result = validateConfig({
+			debug: true,
+			host: "localhost",
+			port: 8080,
+		});
+		expect(result).toEqual([]);
+	});
+
+	it("should return an error if the field is an array", () => {
+		const result = validateConfig(["array", "of", "values"]);
+		expect(result).toEqual(["the type should be `object`, not `array`"]);
+	});
+
+	it("should return an error if the field is null", () => {
+		const result = validateConfig(null);
+		expect(result).toEqual(["the field is `null`, but should be an `object`"]);
+	});
+});

--- a/src/validators/validateConfig.ts
+++ b/src/validators/validateConfig.ts
@@ -1,0 +1,16 @@
+/**
+ * Validate the `config` field in a package.json. The value
+ * should be an object.
+ */
+export const validateConfig = (obj: unknown): string[] => {
+	const errors: string[] = [];
+
+	if (obj === null) {
+		errors.push("the field is `null`, but should be an `object`");
+	} else if (typeof obj !== "object" || Array.isArray(obj)) {
+		const valueType = Array.isArray(obj) ? "array" : typeof obj;
+		errors.push(`the type should be \`object\`, not \`${valueType}\``);
+	}
+
+	return errors;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #309 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateConfig` function that validates the value of the "config" field of a package.json. If returns a list of error messages if a violation is found. Validation of `config` in the monolithic validate function has been switched over to use this function as well. Though, the criteria is the same.

The new function simply validates that the value is an object.
