### PR TITLE
feat(validateLicense): add function for validating `license`

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,25 @@ const packageData = {
 const errors = validateScripts(packageData.config);
 ```
 
+### validateLicense(value)
+
+This function validates the value of the `license` property of a `package.json`.
+It takes the value, and validates it using `validate-npm-package-license`, which is the same package that npm uses.
+
+It returns a list of error messages, if a violation is found.
+
+#### Examples
+
+```ts
+import { validateLicense } from "package-json-validator";
+
+const packageData = {
+	license: "MIT",
+};
+
+const errors = validateType(packageData.license);
+```
+
 ### validateScripts(value)
 
 This function validates the value of the `scripts` property of a `package.json`.

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"*": "prettier --ignore-unknown --write"
 	},
 	"dependencies": {
+		"validate-npm-package-license": "^3.0.4",
 		"yargs": "~18.0.0"
 	},
 	"devDependencies": {
@@ -73,6 +74,7 @@
 		"@release-it/conventional-changelog": "10.0.0",
 		"@types/eslint-plugin-markdown": "2.0.2",
 		"@types/node": "22.16.0",
+		"@types/validate-npm-package-license": "^3.0.3",
 		"@types/yargs": "17.0.33",
 		"@vitest/coverage-v8": "3.2.0",
 		"@vitest/eslint-plugin": "1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      validate-npm-package-license:
+        specifier: ^3.0.4
+        version: 3.0.4
       yargs:
         specifier: ~18.0.0
         version: 18.0.0
@@ -27,6 +30,9 @@ importers:
       '@types/node':
         specifier: 22.16.0
         version: 22.16.0
+      '@types/validate-npm-package-license':
+        specifier: ^3.0.3
+        version: 3.0.3
       '@types/yargs':
         specifier: 17.0.33
         version: 17.0.33
@@ -1002,6 +1008,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/validate-npm-package-license@3.0.3':
+    resolution: {integrity: sha512-uu5D5tHla4R+dEKKmF7NxlK4UHiEwqR8hgm1zF3ISBd5MnmNvTDYEcB77zEpAybHDEPgUVDFhOtU8V4LwuFGXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -3983,6 +3992,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/validate-npm-package-license@3.0.3': {}
 
   '@types/yargs-parser@21.0.3': {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export {
 	validateBin,
 	validateBundleDependencies,
 	validateConfig,
+	validateLicense,
 	validateScripts,
 	validateType,
 } from "./validators/index.js";

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -12,6 +12,7 @@ import {
 	validateBundleDependencies,
 	validateConfig,
 	validateDependencies,
+	validateLicense,
 	validateScripts,
 	validateType,
 	validateUrlOrMailto,
@@ -50,7 +51,7 @@ const getSpecMap = (
 			files: { type: "array" },
 			homepage: { format: urlFormat, recommended: true, type: "string" },
 			keywords: { type: "array", warning: true },
-			license: { type: "string" },
+			license: { validate: (_, value) => validateLicense(value) },
 			licenses: {
 				or: "license",
 				type: "array",

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -3,6 +3,7 @@ export { validateBin } from "./validateBin.js";
 export { validateBundleDependencies } from "./validateBundleDependencies.js";
 export { validateConfig } from "./validateConfig.js";
 export { validateDependencies } from "./validateDependencies.js";
+export { validateLicense } from "./validateLicense.js";
 export { validateScripts } from "./validateScripts.js";
 export { validateType } from "./validateType.js";
 export { validateUrlOrMailto } from "./validateUrlOrMailto.js";

--- a/src/validators/validateLicense.test.ts
+++ b/src/validators/validateLicense.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { validateLicense } from "./validateLicense.js";
+
+describe("validateLicense", () => {
+	it.each([
+		"MIT",
+		"BSD-2-Clause",
+		"Apache-2.0",
+		"ISC",
+		"UNLICENSED",
+		"(GPL-3.0-only OR BSD-2-Clause)",
+		"SEE LICENSE IN license.md",
+		"SEE LICENCE IN license.md",
+	])("should return no errors for valid license '%s'", (license) => {
+		expect(validateLicense(license)).toEqual([]);
+	});
+
+	it("should return error if the value is not a string (number)", () => {
+		expect(validateLicense(123)).toEqual([
+			"the type should be a `string`, not `number`",
+		]);
+	});
+
+	it("should return error if the value is not a string (object)", () => {
+		expect(validateLicense({})).toEqual([
+			"the type should be a `string`, not `object`",
+		]);
+	});
+
+	it("should return error if the value is not a string (array)", () => {
+		expect(validateLicense([])).toEqual([
+			"the type should be a `string`, not `Array`",
+		]);
+	});
+
+	it("should return error if value is not a string (boolean)", () => {
+		expect(validateLicense(true)).toEqual([
+			"the type should be a `string`, not `boolean`",
+		]);
+	});
+
+	it("should return error if value is not a string (undefined)", () => {
+		expect(validateLicense(undefined)).toEqual([
+			"the type should be a `string`, not `undefined`",
+		]);
+	});
+
+	it("should return error if value is not a string (null)", () => {
+		expect(validateLicense(null)).toEqual([
+			"the field is `null`, but should be a `string`",
+		]);
+	});
+
+	it("should return error if the value is an empty string", () => {
+		expect(validateLicense("")).toEqual([
+			"the value is empty, but should be a valid license",
+		]);
+	});
+
+	it("should return error if the value is whitespace only", () => {
+		expect(validateLicense("   ")).toEqual([
+			"the value is empty, but should be a valid license",
+		]);
+	});
+
+	it("should return error if the value is an invalid string", () => {
+		expect(validateLicense("LicenseRef-Made-Up")).toHaveLength(1);
+	});
+});

--- a/src/validators/validateLicense.ts
+++ b/src/validators/validateLicense.ts
@@ -19,7 +19,6 @@ export const validateLicense = (license: unknown): string[] => {
 	if (license.trim() === "") {
 		errors.push("the value is empty, but should be a valid license");
 	} else {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-call -- not sure why this is complaining, seems to be false positive
 		const validationResults = valid(license);
 		if (validationResults.warnings) {
 			errors.push(...validationResults.warnings);

--- a/src/validators/validateLicense.ts
+++ b/src/validators/validateLicense.ts
@@ -1,0 +1,30 @@
+import valid from "validate-npm-package-license";
+
+/**
+ * Validate the `license` field in a package.json, using `validate-npm-package-license`.
+ */
+export const validateLicense = (license: unknown): string[] => {
+	const errors: string[] = [];
+
+	if (typeof license !== "string") {
+		if (license === null) {
+			errors.push("the field is `null`, but should be a `string`");
+		} else {
+			const valueType = Array.isArray(license) ? "Array" : typeof license;
+			errors.push(`the type should be a \`string\`, not \`${valueType}\``);
+		}
+		return errors;
+	}
+
+	if (license.trim() === "") {
+		errors.push("the value is empty, but should be a valid license");
+	} else {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call -- not sure why this is complaining, seems to be false positive
+		const validationResults = valid(license);
+		if (validationResults.warnings) {
+			errors.push(...validationResults.warnings);
+		}
+	}
+
+	return errors;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #344 #341 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateLicense` function that validates the value of the "license" field of a package.json. If returns a list of error messages if a violation is found. Validation of `license` in the monolithic validate function has been switched over to use this function as well. That means the criteria for license, when running validate, is stricter than it was before.

The new function uses `validate-npm-package-license` to validate the value (after first checking that it's a non-empty string).  Previously it was just validating that the value was a string.
