### PR TITLE
feat(validateVersion): add function for validating `version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,25 @@ const packageData = {
 const errors = validateType(packageData.type);
 ```
 
+### validateVersion(value)
+
+This function validates the value of the `version` property of a `package.json`.
+It takes the value, and validates it using `semver`, which is the same package that npm uses.
+
+It returns a list of error messages, if a violation is found.
+
+#### Examples
+
+```ts
+import { validateVersion } from "package-json-validator";
+
+const packageData = {
+	version: "1.2.3",
+};
+
+const errors = validateVersion(packageData.version);
+```
+
 ## Specification
 
 This package uses the `npm` [spec](https://docs.npmjs.com/cli/configuring-npm/package-json) along with additional [supporting documentation from node](https://nodejs.org/api/packages.html), as its source of truth for validation.

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"*": "prettier --ignore-unknown --write"
 	},
 	"dependencies": {
+		"semver": "^7.7.2",
 		"validate-npm-package-license": "^3.0.4",
 		"yargs": "~18.0.0"
 	},
@@ -74,6 +75,7 @@
 		"@release-it/conventional-changelog": "10.0.0",
 		"@types/eslint-plugin-markdown": "2.0.2",
 		"@types/node": "22.16.0",
+		"@types/semver": "^7.7.0",
 		"@types/validate-npm-package-license": "3.0.3",
 		"@types/yargs": "17.0.33",
 		"@vitest/coverage-v8": "3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      semver:
+        specifier: ^7.7.2
+        version: 7.7.2
       validate-npm-package-license:
         specifier: ^3.0.4
         version: 3.0.4
@@ -30,6 +33,9 @@ importers:
       '@types/node':
         specifier: 22.16.0
         version: 22.16.0
+      '@types/semver':
+        specifier: ^7.7.0
+        version: 7.7.0
       '@types/validate-npm-package-license':
         specifier: 3.0.3
         version: 3.0.3
@@ -1000,8 +1006,8 @@ packages:
   '@types/parse-path@7.0.3':
     resolution: {integrity: sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==}
 
-  '@types/semver@7.5.8':
-    resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
+  '@types/semver@7.7.0':
+    resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -3349,7 +3355,7 @@ snapshots:
 
   '@conventional-changelog/git-client@1.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.0.0)':
     dependencies:
-      '@types/semver': 7.5.8
+      '@types/semver': 7.7.0
       semver: 7.7.2
     optionalDependencies:
       conventional-commits-filter: 5.0.0
@@ -3987,7 +3993,7 @@ snapshots:
 
   '@types/parse-path@7.0.3': {}
 
-  '@types/semver@7.5.8': {}
+  '@types/semver@7.7.0': {}
 
   '@types/unist@2.0.11': {}
 
@@ -4438,7 +4444,7 @@ snapshots:
 
   conventional-changelog-writer@8.0.0:
     dependencies:
-      '@types/semver': 7.5.8
+      '@types/semver': 7.7.0
       conventional-commits-filter: 5.0.0
       handlebars: 4.7.8
       meow: 13.2.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,5 @@ export {
 	validateLicense,
 	validateScripts,
 	validateType,
+	validateVersion,
 } from "./validators/index.js";

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -16,6 +16,7 @@ import {
 	validateScripts,
 	validateType,
 	validateUrlOrMailto,
+	validateVersion,
 } from "./validators/index.js";
 
 const getSpecMap = (
@@ -86,9 +87,8 @@ const getSpecMap = (
 			scripts: { validate: (_, value) => validateScripts(value) },
 			type: { recommended: true, validate: (_, value) => validateType(value) },
 			version: {
-				format: versionFormat,
 				required: !isPrivate,
-				type: "string",
+				validate: (_, value) => validateVersion(value),
 			},
 		};
 	} else if (specName == "commonjs_1.0") {

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -7,3 +7,4 @@ export { validateLicense } from "./validateLicense.js";
 export { validateScripts } from "./validateScripts.js";
 export { validateType } from "./validateType.js";
 export { validateUrlOrMailto } from "./validateUrlOrMailto.js";
+export { validateVersion } from "./validateVersion.js";

--- a/src/validators/validateVersion.test.ts
+++ b/src/validators/validateVersion.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { validateVersion } from "./validateVersion.js";
+
+describe("validateVersion", () => {
+	it.each([
+		"1.2.3",
+		"1.2.3-beta.0",
+		"0.0.0-experimental-2f0e7e57-20250715",
+		"0.0.0",
+		"1.2.3-rc.1+rev.2",
+	])("should return no errors for valid version '%s'", (version) => {
+		expect(validateVersion(version)).toEqual([]);
+	});
+
+	it("should return error if the value is not a string (number)", () => {
+		expect(validateVersion(123)).toEqual([
+			"the type should be a `string`, not `number`",
+		]);
+	});
+
+	it("should return error if the value is not a string (object)", () => {
+		expect(validateVersion({})).toEqual([
+			"the type should be a `string`, not `object`",
+		]);
+	});
+
+	it("should return error if the value is not a string (array)", () => {
+		expect(validateVersion([])).toEqual([
+			"the type should be a `string`, not `Array`",
+		]);
+	});
+
+	it("should return error if value is not a string (boolean)", () => {
+		expect(validateVersion(true)).toEqual([
+			"the type should be a `string`, not `boolean`",
+		]);
+	});
+
+	it("should return error if value is not a string (undefined)", () => {
+		expect(validateVersion(undefined)).toEqual([
+			"the type should be a `string`, not `undefined`",
+		]);
+	});
+
+	it("should return error if value is not a string (null)", () => {
+		expect(validateVersion(null)).toEqual([
+			"the field is `null`, but should be a `string`",
+		]);
+	});
+
+	it("should return error if the value is an empty string", () => {
+		expect(validateVersion("")).toEqual([
+			"the value is empty, but should be a valid version",
+		]);
+	});
+
+	it("should return error if the value is whitespace only", () => {
+		expect(validateVersion("   ")).toEqual([
+			"the value is empty, but should be a valid version",
+		]);
+	});
+
+	it.each(["^1.2.3", "~1.2.3", "invalid", "1.2.3.4.5-alpha2", "1.2", "1"])(
+		"should return error for invalid version '%s'",
+		(version) => {
+			expect(validateVersion(version)).toEqual([
+				"the value is not a valid semver version",
+			]);
+		},
+	);
+});

--- a/src/validators/validateVersion.ts
+++ b/src/validators/validateVersion.ts
@@ -1,0 +1,28 @@
+import { valid } from "semver";
+
+/**
+ * Validate the `version` field in a package.json, using `semver`.
+ */
+export const validateVersion = (version: unknown): string[] => {
+	const errors: string[] = [];
+
+	if (typeof version !== "string") {
+		if (version === null) {
+			errors.push("the field is `null`, but should be a `string`");
+		} else {
+			const valueType = Array.isArray(version) ? "Array" : typeof version;
+			errors.push(`the type should be a \`string\`, not \`${valueType}\``);
+		}
+		return errors;
+	}
+
+	if (version.trim() === "") {
+		errors.push("the value is empty, but should be a valid version");
+	} else {
+		if (!valid(version)) {
+			errors.push("the value is not a valid semver version");
+		}
+	}
+
+	return errors;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #349 #340
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateVersion` function that validates the value of the "version" field of a package.json. It returns a list of error messages if a violation is found. Validation of `version` in the monolithic validate function has been switched over to use this function as well. That means the criteria for version, when running validate, is possibly stricter.

The new function uses `semver` to validate the value (after first checking that it's a non-empty string).  Previously it was using a bespoke regex pattern to validate.
