### PR TITLE
feat(validateCpu): add function for validating `cpu`

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ const packageData = {
 	bundleDependencies: ["renderized", "super-streams"],
 };
 
-const errors = validateBundleDependencies(packageData.packageData);
+const errors = validateBundleDependencies(packageData.bundleDependencies);
 ```
 
 ### validateConfig(value)
@@ -260,6 +260,28 @@ const packageData = {
 };
 
 const errors = validateScripts(packageData.config);
+```
+
+### validateCpu(value)
+
+This function validates the value of the `cpu` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- the property is an array
+- all items in the array should be non-empty strings
+
+It returns a list of error messages, if any violations are found.
+
+#### Examples
+
+```ts
+import { validateCpu } from "package-json-validator";
+
+const packageData = {
+	cpu: ["x64", "ia32"],
+};
+
+const errors = validateCpu(packageData.cpu);
 ```
 
 ### validateLicense(value)

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -11,6 +11,7 @@ import {
 	validateBin,
 	validateBundleDependencies,
 	validateConfig,
+	validateCpu,
 	validateDependencies,
 	validateLicense,
 	validateScripts,
@@ -38,7 +39,7 @@ const getSpecMap = (
 			},
 			config: { validate: (_, value) => validateConfig(value) },
 			contributors: { validate: validatePeople },
-			cpu: { type: "array" },
+			cpu: { validate: (_, value) => validateCpu(value) },
 			dependencies: {
 				recommended: true,
 				type: "object",

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -2,6 +2,7 @@ export { validateAuthor } from "./validateAuthor.js";
 export { validateBin } from "./validateBin.js";
 export { validateBundleDependencies } from "./validateBundleDependencies.js";
 export { validateConfig } from "./validateConfig.js";
+export { validateCpu } from "./validateCpu.js";
 export { validateDependencies } from "./validateDependencies.js";
 export { validateLicense } from "./validateLicense.js";
 export { validateScripts } from "./validateScripts.js";

--- a/src/validators/validateCpu.test.ts
+++ b/src/validators/validateCpu.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { validateCpu } from "./validateCpu.js";
+
+describe("validateCpu", () => {
+	it("should return no errors if the value is an empty array", () => {
+		const result = validateCpu([]);
+		expect(result).toEqual([]);
+	});
+
+	it("should return no errors if the value is a valid array with all strings", () => {
+		const result = validateCpu(["nin", "thee-silver-mt-zion"]);
+		expect(result).toEqual([]);
+	});
+
+	it("should return errors if the value is an array with some non-string values", () => {
+		const result = validateCpu(["nin", null, "thee-silver-mt-zion", 123]);
+		expect(result).toEqual([
+			"item at index 1 should be a string, not `null`",
+			"item at index 3 should be a string, not `number`",
+		]);
+	});
+
+	it("should return an error if the value is an array with non-empty strings", () => {
+		const result = validateCpu(["", "nin", "", "thee-silver-mt-zion"]);
+		expect(result).toEqual([
+			"item at index 0 is empty, but should be the name of a cpu architecture",
+			"item at index 2 is empty, but should be the name of a cpu architecture",
+		]);
+	});
+
+	it("should return an error if the value is a number", () => {
+		const result = validateCpu(123);
+		expect(result).toEqual(["the type should be `Array`, not `number`"]);
+	});
+
+	it("should return an error if the value is an object", () => {
+		const result = validateCpu({});
+		expect(result).toEqual(["the type should be `Array`, not `object`"]);
+	});
+
+	it("should return an error if the value is null", () => {
+		const result = validateCpu(null);
+		expect(result).toEqual([
+			"the field is `null`, but should be an `Array` of strings",
+		]);
+	});
+});

--- a/src/validators/validateCpu.ts
+++ b/src/validators/validateCpu.ts
@@ -1,0 +1,33 @@
+/**
+ * Validate the `cpu` field in a package.json, which should be an array of
+ * strings.
+ *
+ * ["x64", "ia32"]
+ */
+export const validateCpu = (obj: unknown): string[] => {
+	const errors: string[] = [];
+
+	if (Array.isArray(obj)) {
+		// If it's an array, check if all items are non-empty strings
+		for (let i = 0; i < obj.length; i++) {
+			const item = obj[i];
+			if (typeof item !== "string") {
+				const itemType = item === null ? "null" : typeof item;
+				errors.push(
+					`item at index ${i} should be a string, not \`${itemType}\``,
+				);
+			} else if (item.trim() === "") {
+				errors.push(
+					`item at index ${i} is empty, but should be the name of a cpu architecture`,
+				);
+			}
+		}
+	} else if (obj == null) {
+		errors.push("the field is `null`, but should be an `Array` of strings");
+	} else {
+		const valueType = typeof obj;
+		errors.push(`the type should be \`Array\`, not \`${valueType}\``);
+	}
+
+	return errors;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #310
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateCpu` function that validates the value of the "cpu" field of a package.json. It returns a list of error messages if a violation is found. Validation of `cpu` in the monolithic validate function has been switched over to use this function as well. That means the criteria for `cpu`, when running `validate`, is stricter.

The new function validates that the value is an array of non-empty strings.  Previously it only checked that the value was an array.
