### PR TITLE
chore: fix bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -7,7 +7,8 @@ labels:
   - "type: bug"
 
 body:
-  - attributes:
+  - type: checkboxes
+    attributes:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
       label: Bug Report Checklist
       options:
@@ -15,26 +16,26 @@ body:
           required: true
         - label: I have [searched for related issues](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aissue) and found none that matched my issue.
           required: true
-    type: checkboxes
-  - attributes:
+  - type: textarea
+    attributes:
       description: What did you expect to happen?
       label: Expected
-    type: textarea
     validations:
       required: true
-  - attributes:
+  - type: textarea
+    attributes:
       description: What happened instead?
       label: Actual
-    type: textarea
     validations:
       required: true
-  - attributes:
+  - type: input
+    attributes:
       description: Version of this package you tried
       label: Version
       placeholder: 1.2.3
+    validations:
       required: true
-    type: input
-  - attributes:
+  - type: textarea
+    attributes:
       description: Any additional info you'd like to provide.
       label: Additional Info
-    type: textarea


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change corrects and error in the format of the bug template.  `required` was under `attributes` instead of `validations`.
