### PR TITLE
feat: deprecate CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,25 +17,6 @@
 
 ## Usage
 
-### Command line
-
-```shell
-npm install package-json-validator -g
-```
-
-See `pjv --help` for usage:
-
-```plaintext
-Options:
-  --filename, -f         package.json file to validate                      [default: "package.json"]
-  --warnings, -w         display warnings                                   [default: false]
-  --recommendations, -r  display recommendations                            [default: false]
-  --quiet, -q            less output                                        [default: false]
-  --help, -h, -?         this help message                                  [default: false]
-```
-
-### Node.js
-
 ```shell
 npm install package-json-validator
 ```
@@ -45,6 +26,11 @@ import { validate } from "package-json-validator";
 
 validate(/* ... */);
 ```
+
+For tools that run these validations, see:
+
+- [eslint-plugin-package-json](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json): to detect all violations and keep them warned against via ESLint
+- [package-json-validator-cli](https://github.com/JoshuaKGoldberg/package-json-validator-cli): if you want just a one-shot tool to run in the CLI
 
 ## API
 

--- a/src/bin/pjv.ts
+++ b/src/bin/pjv.ts
@@ -56,6 +56,12 @@ const options = yargs(process.argv.slice(2))
 	.usage("Validate package.json files")
 	.parse() as Options;
 
+if (!options.quiet) {
+	console.warn(
+		"The pjv CLI in package-json-validator is deprecated and will be removed soon. Please use package-json-validator-cli instead.",
+	);
+}
+
 if (!fs.existsSync(options.filename)) {
 	console.error("File does not exist: " + options.filename);
 	process.exitCode = 1;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #264
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a deprecation notice as suggested in https://github.com/JoshuaKGoldberg/package-json-validator/issues/264#issuecomment-3212272711. Also replaces the CLI docs from the README.md with links to [eslint-plugin-package-json](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json) and [package-json-validator-cli](https://github.com/JoshuaKGoldberg/package-json-validator-cli).

As noted in that comment, _removing_ the CLI will need to be a followup issue blocked for 6 months.

💖