### PR TITLE
feat: add function to validate `packageManager`

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,26 @@ const packageData = {
 const result = validateOs(packageData.os);
 ```
 
+### validatePackageManager(value)
+
+This function validates the value of the `packageManager` property of a `package.json`.
+It takes the value, and checks that it's a string with a valid package manager and version.
+The package manager portion should be `npm`, `pnpm`, or `yarn`, while the version portion should be a valid semver version.
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validatePrivate } from "package-json-validator";
+
+const packageData = {
+	packageManager: "pnpm@10.3.0",
+};
+
+const result = validatePackageManager(packageData.packageManager);
+```
+
 ### validatePrivate(value)
 
 This function validates the value of the `private` property of a `package.json`.

--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ const result = validateOs(packageData.os);
 
 This function validates the value of the `packageManager` property of a `package.json`.
 It takes the value, and checks that it's a string with a valid package manager and version.
-The package manager portion should be `npm`, `pnpm`, or `yarn`, while the version portion should be a valid semver version.
+The package manager portion should be `npm`, `pnpm`, `yarn`, `bun`, or `deno`, while the version portion should be a valid semver version.
 
 It returns a `Result` object (See [Result Types](#result-types)).
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {
 	validateName,
 	validateDependencies as validateOptionalDependencies,
 	validateOs,
+	validatePackageManager,
 	validateDependencies as validatePeerDependencies,
 	validatePrivate,
 	validatePublishConfig,

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -17,6 +17,7 @@ export { validateMain } from "./validateMain.ts";
 export { validateMan } from "./validateMan.ts";
 export { validateName } from "./validateName.ts";
 export { validateOs } from "./validateOs.ts";
+export { validatePackageManager } from "./validatePackageManager.ts";
 export { validatePrivate } from "./validatePrivate.ts";
 export { validatePublishConfig } from "./validatePublishConfig.ts";
 export { validateRepository } from "./validateRepository.ts";

--- a/src/validators/validatePackageManager.test.ts
+++ b/src/validators/validatePackageManager.test.ts
@@ -100,7 +100,7 @@ describe(validatePackageManager, () => {
 		const result = validatePackageManager("pnpm@invalid");
 
 		expect(result.errorMessages).toEqual([
-			'the version "invalid" is not valid. It should be a valid semver version (with optional hash).',
+			'the version "invalid" is not valid. It should be a valid semver version (optionally with a hash).',
 		]);
 	});
 
@@ -108,7 +108,7 @@ describe(validatePackageManager, () => {
 		const result = validatePackageManager("pnpm@^10.3.0");
 
 		expect(result.errorMessages).toEqual([
-			'the version "^10.3.0" is not valid. It should be a valid semver version (with optional hash).',
+			'the version "^10.3.0" is not valid. It should be a valid semver version (optionally with a hash).',
 		]);
 	});
 
@@ -117,7 +117,7 @@ describe(validatePackageManager, () => {
 
 		expect(result.errorMessages).toEqual([
 			'the package manager "unsupported" is not supported. Supported package managers are: npm, pnpm, yarn, bun',
-			'the version "invalid" is not valid. It should be a valid semver version (with optional hash).',
+			'the version "invalid" is not valid. It should be a valid semver version (optionally with a hash).',
 		]);
 	});
 });

--- a/src/validators/validatePackageManager.test.ts
+++ b/src/validators/validatePackageManager.test.ts
@@ -8,6 +8,7 @@ describe(validatePackageManager, () => {
 		"pnpm@10.3.0",
 		"yarn@4.2.3",
 		"bun@1.0.0",
+		"deno@1.0.0",
 		"yarn@4.2.3+sha224.953c8233f7a92884eee2de69a1b92d1f2ec1655e66d08071ba9a02fa",
 	])(
 		"should return no issues for valid package manager '%s'",
@@ -92,7 +93,7 @@ describe(validatePackageManager, () => {
 		const result = validatePackageManager("invalid@10.3.0");
 
 		expect(result.errorMessages).toEqual([
-			'the package manager "invalid" is not supported. Supported package managers are: npm, pnpm, yarn, bun',
+			'the package manager "invalid" is not supported. Supported package managers are: npm, pnpm, yarn, bun, deno',
 		]);
 	});
 
@@ -116,7 +117,7 @@ describe(validatePackageManager, () => {
 		const result = validatePackageManager("unsupported@invalid");
 
 		expect(result.errorMessages).toEqual([
-			'the package manager "unsupported" is not supported. Supported package managers are: npm, pnpm, yarn, bun',
+			'the package manager "unsupported" is not supported. Supported package managers are: npm, pnpm, yarn, bun, deno',
 			'the version "invalid" is not valid. It should be a valid semver version (optionally with a hash).',
 		]);
 	});

--- a/src/validators/validatePackageManager.test.ts
+++ b/src/validators/validatePackageManager.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { validatePackageManager } from "./validatePackageManager.ts";
+
+describe(validatePackageManager, () => {
+	it.each([
+		"npm@11.1.0",
+		"pnpm@10.3.0",
+		"yarn@4.2.3",
+		"bun@1.0.0",
+		"yarn@4.2.3+sha224.953c8233f7a92884eee2de69a1b92d1f2ec1655e66d08071ba9a02fa",
+	])(
+		"should return no issues for valid package manager '%s'",
+		(packageManager) => {
+			expect(validatePackageManager(packageManager).errorMessages).toEqual([]);
+		},
+	);
+
+	it("should return an issue if the value is not a string (number)", () => {
+		const result = validatePackageManager(123);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `number`",
+		]);
+	});
+
+	it("should return an issue if the value is not a string (object)", () => {
+		const result = validatePackageManager({});
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `object`",
+		]);
+	});
+
+	it("should return an issue if the value is not a string (array)", () => {
+		const result = validatePackageManager([]);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `array`",
+		]);
+	});
+
+	it("should return an issue if the value is not a string (boolean)", () => {
+		const result = validatePackageManager(true);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `boolean`",
+		]);
+	});
+
+	it("should return an issue if the value is not a string (undefined)", () => {
+		const result = validatePackageManager(undefined);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `undefined`",
+		]);
+	});
+
+	it("should return an issue if the value is not a string (null)", () => {
+		const result = validatePackageManager(null);
+
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be a `string`",
+		]);
+	});
+
+	it("should return an issue if the value is an empty string", () => {
+		const result = validatePackageManager("");
+
+		expect(result.errorMessages).toEqual([
+			'the value is empty, but should be the name and version of a package manager (e.g. "pnpm@10.3.0")',
+		]);
+	});
+
+	it("should return an issue if the value is whitespace only", () => {
+		const result = validatePackageManager("   ");
+
+		expect(result.errorMessages).toEqual([
+			'the value is empty, but should be the name and version of a package manager (e.g. "pnpm@10.3.0")',
+		]);
+	});
+
+	it("should return an issue if the value is not in the correct format", () => {
+		const result = validatePackageManager("pnpm");
+
+		expect(result.errorMessages).toEqual([
+			'the value should be in the form "name@version" (e.g. "pnpm@10.3.0")',
+		]);
+	});
+
+	it("should return an issue if the value doesn't have a supported package manager", () => {
+		const result = validatePackageManager("invalid@10.3.0");
+
+		expect(result.errorMessages).toEqual([
+			'the package manager "invalid" is not supported. Supported package managers are: npm, pnpm, yarn, bun',
+		]);
+	});
+
+	it("should return an issue if the value doesn't have a valid version", () => {
+		const result = validatePackageManager("pnpm@invalid");
+
+		expect(result.errorMessages).toEqual([
+			'the version "invalid" is not valid. It should be a valid semver version (with optional hash).',
+		]);
+	});
+
+	it("should return an issue if the value uses a semver range instead of exact version", () => {
+		const result = validatePackageManager("pnpm@^10.3.0");
+
+		expect(result.errorMessages).toEqual([
+			'the version "^10.3.0" is not valid. It should be a valid semver version (with optional hash).',
+		]);
+	});
+
+	it("should return issues if the value has neither a supported package manager nor a valid version", () => {
+		const result = validatePackageManager("unsupported@invalid");
+
+		expect(result.errorMessages).toEqual([
+			'the package manager "unsupported" is not supported. Supported package managers are: npm, pnpm, yarn, bun',
+			'the version "invalid" is not valid. It should be a valid semver version (with optional hash).',
+		]);
+	});
+});

--- a/src/validators/validatePackageManager.ts
+++ b/src/validators/validatePackageManager.ts
@@ -1,6 +1,6 @@
 import { Result } from "../Result.ts";
 
-const packageManagers = ["npm", "pnpm", "yarn", "bun"];
+const packageManagers = ["npm", "pnpm", "yarn", "bun", "deno"];
 const versionRegex =
 	/^\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?(?:\+sha(?:224|256|384|512)\.[a-fA-F0-9]+)?$/;
 

--- a/src/validators/validatePackageManager.ts
+++ b/src/validators/validatePackageManager.ts
@@ -1,0 +1,57 @@
+import { Result } from "../Result.ts";
+
+const packageManagers = ["npm", "pnpm", "yarn", "bun"];
+const versionRegex =
+	/^\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?(?:\+sha(?:224|256|384|512)\.[a-fA-F0-9]+)?$/;
+
+const validatePackageManagerString = (value: string): string[] => {
+	const results: string[] = [];
+
+	if (!value.includes("@")) {
+		results.push(
+			'the value should be in the form "name@version" (e.g. "pnpm@10.3.0")',
+		);
+	} else {
+		const [name, version] = value.split("@");
+		if (!packageManagers.includes(name)) {
+			results.push(
+				`the package manager "${name}" is not supported. Supported package managers are: ${packageManagers.join(", ")}`,
+			);
+		}
+		if (!version || !versionRegex.test(version)) {
+			results.push(
+				`the version "${version}" is not valid. It should be a valid semver version (with optional hash).`,
+			);
+		}
+	}
+
+	return results;
+};
+
+/**
+ * Validate the `packageManager` field in a package.json, which should be a string
+ * in the format "npm@version", "pnpm@version", or "yarn@version".
+ */
+export const validatePackageManager = (type: unknown): Result => {
+	const result = new Result();
+
+	if (typeof type !== "string") {
+		if (type === null) {
+			result.addIssue("the value is `null`, but should be a `string`");
+		} else {
+			const valueType = Array.isArray(type) ? "array" : typeof type;
+			result.addIssue(`the type should be a \`string\`, not \`${valueType}\``);
+		}
+	} else if (type.trim() === "") {
+		result.addIssue(
+			'the value is empty, but should be the name and version of a package manager (e.g. "pnpm@10.3.0")',
+		);
+	} else {
+		const errors = validatePackageManagerString(type);
+		for (const error of errors) {
+			result.addIssue(error);
+		}
+	}
+
+	return result;
+};

--- a/src/validators/validatePackageManager.ts
+++ b/src/validators/validatePackageManager.ts
@@ -20,7 +20,7 @@ const validatePackageManagerString = (value: string): string[] => {
 		}
 		if (!version || !versionRegex.test(version)) {
 			results.push(
-				`the version "${version}" is not valid. It should be a valid semver version (with optional hash).`,
+				`the version "${version}" is not valid. It should be a valid semver version (optionally with a hash).`,
 			);
 		}
 	}


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #742
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validatePackageManager` function.  It checks that the value is a string, with a valid package manager and version defined, optionally with a sha hash.
