### PR TITLE
feat: add function to validate `funding`

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,39 @@ const packageData = {
 const result = validateFiles(packageData.files);
 ```
 
+### validateFunding(value)
+
+This function validates the value of the `funding` property of a `package.json`.
+It takes the value, and validates that it's one of the following.
+
+- a `string` url
+- an `object` with properties `type` and `url`, with `url` being a valid url
+- an `Array` consisting of items of the above two
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateFunding } from "package-json-validator";
+
+const packageData = {
+	funding: [
+		{
+			type: "individual",
+			url: "http://npmjs.com/donate",
+		},
+		"http://npmjs.com/donate-also",
+		{
+			type: "patreon",
+			url: "https://www.patreon.com/user",
+		},
+	],
+};
+
+const result = validateFunding(packageData.funding);
+```
+
 ### validateHomepage(value)
 
 This function validates the value of the `homepage` property of a `package.json`, checking that the value is a string containing a valid url.

--- a/src/Result.test.ts
+++ b/src/Result.test.ts
@@ -115,8 +115,19 @@ describe(Result, () => {
 
 				result.addIssue("new issue");
 
-				expect(result.issues).toEqual([{ message: "new issue" }]);
+				expect(result.issues).toHaveLength(1);
 				expect(result.errorMessages).toEqual(["new issue"]);
+			});
+		});
+
+		describe("addIssues", () => {
+			it("should add multiple issues", () => {
+				const result = new Result();
+
+				result.addIssues(["new issue 1", "new issue 2"]);
+
+				expect(result.issues).toHaveLength(2);
+				expect(result.errorMessages).toEqual(["new issue 1", "new issue 2"]);
 			});
 		});
 

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -90,6 +90,15 @@ export class Result {
 	}
 
 	/**
+	 * Creates a new {@link Issue} for each message and adds them to this Result.
+	 */
+	public addIssues(messages: string[]): void {
+		for (const message of messages) {
+			this.addIssue(message);
+		}
+	}
+
+	/**
 	 * Flattens this Result object (along with all child results) and pulls all issues from flattened child results into the top-level result.
 	 */
 	public flatten(): this {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export {
 	validateEngines,
 	validateExports,
 	validateFiles,
+	validateFunding,
 	validateHomepage,
 	validateKeywords,
 	validateLicense,

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -10,6 +10,7 @@ export { validateDirectories } from "./validateDirectories.ts";
 export { validateEngines } from "./validateEngines.ts";
 export { validateExports } from "./validateExports.ts";
 export { validateFiles } from "./validateFiles.ts";
+export { validateFunding } from "./validateFunding.ts";
 export { validateHomepage } from "./validateHomepage.ts";
 export { validateKeywords } from "./validateKeywords.ts";
 export { validateLicense } from "./validateLicense.ts";

--- a/src/validators/validateFunding.test.ts
+++ b/src/validators/validateFunding.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { validateFunding } from "./validateFunding.ts";
+
+describe(validateFunding, () => {
+	const mockBadFundingObject = {
+		email: "treznor@nin.com",
+		type: "patreon",
+	};
+	const mockGoodFundingObject = {
+		type: "patreon",
+		url: "https://www.patreon.com/treznor",
+	};
+	const mockBadFundingString = "not-a-url";
+	const mockGoodFundingString = "https://www.patreon.com/treznor";
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it.each([
+		{ description: "a valid funding object", value: mockGoodFundingObject },
+		{ description: "a valid funding string", value: mockGoodFundingString },
+		{
+			description: "a valid funding array",
+			value: [
+				mockGoodFundingObject,
+				mockGoodFundingString,
+				mockGoodFundingObject,
+			],
+		},
+	])("should not return any issues for $description", ({ value }) => {
+		const result = validateFunding(value);
+		expect(result.issues).toHaveLength(0);
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return an issue if the value is not an object, string, or array", () => {
+		const result = validateFunding(123);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the value should be an object with `type` and `url`, a string, or an Array of the two",
+		]);
+	});
+
+	it("should return an issue if the value is a string that's not a valid url", () => {
+		const result = validateFunding(mockBadFundingString);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual(["the value should be a valid URL"]);
+	});
+
+	it("should return an issue if the value is an empty string", () => {
+		const result = validateFunding("");
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be a URL",
+		]);
+	});
+
+	it("should return issues if the value is a funding object with url missing and an extra property", () => {
+		const result = validateFunding(mockBadFundingObject);
+		expect(result.issues).toHaveLength(1);
+		expect(result.childResults).toHaveLength(2);
+		expect(result.errorMessages).toEqual([
+			"missing required property `url` in funding object",
+			"unexpected property `email`; only `type` and `url` are allowed in a funding object",
+		]);
+	});
+
+	it("should return issues if the value is a funding object with type missing", () => {
+		const result = validateFunding({ url: mockGoodFundingString });
+		expect(result.issues).toHaveLength(1);
+		expect(result.childResults).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"missing required property `type` in funding object",
+		]);
+	});
+
+	it("should return issues if the value is a funding object with invalid property values (number)", () => {
+		const mockFundingObjectWithInvalidValues = {
+			type: 123,
+			url: 123,
+		};
+		const result = validateFunding(mockFundingObjectWithInvalidValues);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(2);
+		expect(result.childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[1].issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the `type` property should be a string, but got number",
+			"the `url` property should be a string, but got number",
+		]);
+	});
+
+	it("should return issues if the value is a funding object with invalid property values (null)", () => {
+		const mockFundingObjectWithInvalidValues = {
+			type: null,
+			url: null,
+		};
+		const result = validateFunding(mockFundingObjectWithInvalidValues);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(2);
+		expect(result.childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[1].issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the `type` property should be a string, but got null",
+			"the `url` property should be a string, but got null",
+		]);
+	});
+
+	it("should return issues if the value is a funding object with invalid property values (empty string)", () => {
+		const mockFundingObjectWithInvalidValues = {
+			type: "",
+			url: "",
+		};
+		const result = validateFunding(mockFundingObjectWithInvalidValues);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(2);
+		expect(result.childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[1].issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the `type` property should not be empty",
+			"the `url` property should not be empty",
+		]);
+	});
+
+	it("should return issues if the value is a funding object with invalid property values (invalid url)", () => {
+		const mockFundingObjectWithInvalidValues = {
+			type: "patreon",
+			url: mockBadFundingString,
+		};
+		const result = validateFunding(mockFundingObjectWithInvalidValues);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(2);
+		expect(result.childResults[0].issues).toHaveLength(0);
+		expect(result.childResults[1].issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the `url` property should be a valid URL",
+		]);
+	});
+
+	it("should return issues if the value is an array with some invalid items", () => {
+		const result = validateFunding([
+			mockBadFundingObject,
+			mockGoodFundingObject,
+			mockBadFundingString,
+		]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(3);
+		const badFundingObjectResult = result.childResults[0];
+		const goodFundingObjectResult = result.childResults[1];
+		const badFundingStringResult = result.childResults[2];
+		expect(badFundingObjectResult.errorMessages).toHaveLength(2);
+		expect(goodFundingObjectResult.errorMessages).toHaveLength(0);
+		expect(badFundingStringResult.errorMessages).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"missing required property `url` in funding object",
+			"unexpected property `email`; only `type` and `url` are allowed in a funding object",
+			"the value should be a valid URL",
+		]);
+	});
+});

--- a/src/validators/validateFunding.ts
+++ b/src/validators/validateFunding.ts
@@ -1,0 +1,107 @@
+import { urlFormat } from "../formats.ts";
+import { Result } from "../Result.ts";
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+};
+
+/**
+ * The object should consist of only the properties `type` and `url`, both of which are required.
+ * Both properties should be non-empty strings, and the `url` property should be a valid URL.
+ */
+const validateFundingObject = (value: Record<string, unknown>): Result => {
+	const result = new Result();
+	const keys = Object.keys(value);
+	for (let i = 0; i < keys.length; i++) {
+		const key = keys[i];
+		const childResult = new Result();
+		if (key !== "type" && key !== "url") {
+			childResult.addIssue(
+				`unexpected property \`${key}\`; only \`type\` and \`url\` are allowed in a funding object`,
+			);
+		}
+		if (key === "type") {
+			if (typeof value[key] !== "string") {
+				const valueType = value[key] === null ? "null" : typeof value[key];
+				childResult.addIssue(
+					`the \`type\` property should be a string, but got ${valueType}`,
+				);
+			} else if (value[key].trim() === "") {
+				childResult.addIssue("the `type` property should not be empty");
+			}
+		}
+		if (key === "url") {
+			if (typeof value[key] !== "string") {
+				const valueType = value[key] === null ? "null" : typeof value[key];
+				childResult.addIssue(
+					`the \`url\` property should be a string, but got ${valueType}`,
+				);
+			} else if (value[key].trim() === "") {
+				childResult.addIssue("the `url` property should not be empty");
+			} else if (!urlFormat.test(value[key])) {
+				childResult.addIssue("the `url` property should be a valid URL");
+			}
+		}
+		result.addChildResult(i, childResult);
+	}
+	if (!keys.includes("type")) {
+		result.addIssue("missing required property `type` in funding object");
+	}
+	if (!keys.includes("url")) {
+		result.addIssue("missing required property `url` in funding object");
+	}
+	return result;
+};
+
+const validateFundingString = (value: string): Result => {
+	const result = new Result();
+	if (value.trim() === "") {
+		result.addIssue("the value is empty, but should be a URL");
+	} else if (!urlFormat.test(value)) {
+		result.addIssue("the value should be a valid URL");
+	}
+	return result;
+};
+
+const validateFundingItem = (value: unknown): Result => {
+	let result = new Result();
+	if (typeof value === "string") {
+		result = validateFundingString(value);
+	} else if (isPlainObject(value)) {
+		result = validateFundingObject(value);
+	} else {
+		result.addIssue(
+			"the value should be an object with `type` and `url`, a string, or an Array of the two",
+		);
+	}
+	return result;
+};
+
+/**
+ * Validate the `funding` field in a package.json, which should either be
+ * 1. an object containing a `type` and `url` field
+ * 2. a simple string URL
+ * 3. or an array of the above two
+ *
+ * [
+ *   {
+ *     "type": "patreon",
+ *     "url": "https://www.patreon.com/user"
+ *   },
+ *   "http://npmjs.com/donate-also",
+ * ]
+ */
+export const validateFunding = (value: unknown): Result => {
+	let result = new Result();
+
+	if (Array.isArray(value)) {
+		for (let i = 0; i < value.length; i++) {
+			const item: unknown = value[i];
+			const childResult = validateFundingItem(item);
+			result.addChildResult(i, childResult);
+		}
+	} else {
+		result = validateFundingItem(value);
+	}
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #750
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateFunding` function.  It checks that the value is one of the following:

- a string URL
- an object with properties `type` and `url`, with `url` being a valid URL
- an Array consisting of the above two types
