### PR TITLE
fix(validateFunding): array within array error message isn't accurate

### DIFF
--- a/src/validators/validateFunding.test.ts
+++ b/src/validators/validateFunding.test.ts
@@ -159,4 +159,21 @@ describe(validateFunding, () => {
 			"the value should be a valid URL",
 		]);
 	});
+
+	it("should return issues if the value is an array with items of invalid type", () => {
+		const result = validateFunding([[], 123, null]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(3);
+		const arrayFundingItemResult = result.childResults[0];
+		const numberFundingItemResult = result.childResults[1];
+		const nullFundingItemResult = result.childResults[2];
+		expect(arrayFundingItemResult.errorMessages).toHaveLength(1);
+		expect(numberFundingItemResult.errorMessages).toHaveLength(1);
+		expect(nullFundingItemResult.errorMessages).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the value should be an object with `type` and `url` or a string URL",
+			"the value should be an object with `type` and `url` or a string URL",
+			"the value should be an object with `type` and `url` or a string URL",
+		]);
+	});
 });

--- a/src/validators/validateFunding.ts
+++ b/src/validators/validateFunding.ts
@@ -68,7 +68,7 @@ const validateFundingItem = (value: unknown): Result => {
 		result = validateFundingObject(value);
 	} else {
 		result.addIssue(
-			"the value should be an object with `type` and `url`, a string, or an Array of the two",
+			"the value should be an object with `type` and `url` or a string URL",
 		);
 	}
 	return result;
@@ -97,8 +97,12 @@ export const validateFunding = (value: unknown): Result => {
 			const childResult = validateFundingItem(item);
 			result.addChildResult(i, childResult);
 		}
-	} else {
+	} else if (typeof value === "string" || isPlainObject(value)) {
 		result = validateFundingItem(value);
+	} else {
+		result.addIssue(
+			"the value should be an object with `type` and `url`, a string, or an Array of the two",
+		);
 	}
 	return result;
 };


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adjusts `validateFunding` function to use a different error message, when the top-level funding value is not an object, string, or array, than the message when an array item is not a valid object or string.  Arrays within a funding array aren't valid, and the error message made it seem as though they are.
