### PR TITLE
feat: add function to validate `devEngines`

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,52 @@ const packageData = {
 const result = validateDirectories(packageData.directories);
 ```
 
+### validateDevEngines(value)
+
+This function validates the value of the `devEngines` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- it should be an `object` with any of the following properties
+  - `cpu`
+  - `libc`
+  - `os`
+  - `packageManager`
+  - `runtime`
+- The value of each property should be an object or an Array of objects with the following properties
+  - `name` (required): the name of the engine, e.g. "node", "npm", "yarn", "bun"
+  - `version` (optional): the version of the engine, which should be a valid semver range
+  - `onFail` (optional): should be one of the following values: `warn`, `error`, `ignore` or `download`
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateDevEngines } from "package-json-validator";
+
+const packageData = {
+	devEngines: {
+		runtime: {
+			name: "node",
+			version: "^20.19.0 || >=22.12.0",
+			onFail: "download",
+		},
+		packageManager: {
+			name: "pnpm",
+			version: "^10.0.0",
+			onFail: "error",
+		},
+	},
+};
+
+const result = validateDevEngines(packageData.devEngines);
+```
+
+#### See Also
+
+- https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines
+- https://pnpm.io/package_json#devenginesruntime
+
 ### validateEngines(value)
 
 This function validates the value of the `engines` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
 	validateDependencies,
 	validateDescription,
 	validateDependencies as validateDevDependencies,
+	validateDevEngines,
 	validateDirectories,
 	validateEngines,
 	validateExports,

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -7,6 +7,7 @@ export { validateContributors } from "./validateContributors.ts";
 export { validateCpu } from "./validateCpu.ts";
 export { validateDependencies } from "./validateDependencies.ts";
 export { validateDescription } from "./validateDescription.ts";
+export { validateDevEngines } from "./validateDevEngines.ts";
 export { validateDirectories } from "./validateDirectories.ts";
 export { validateEngines } from "./validateEngines.ts";
 export { validateExports } from "./validateExports.ts";

--- a/src/validators/validateDevEngines.test.ts
+++ b/src/validators/validateDevEngines.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+
+import { validateDevEngines } from "./validateDevEngines.ts";
+
+describe(validateDevEngines, () => {
+	const completeDevEngineObject = {
+		name: "node",
+		onFail: "warn",
+		version: "^20.19.0 || >=22.12.0",
+	};
+	const partialDevEngineObject = {
+		name: "node",
+		version: "^20.19.0 || >=22.12.0",
+	};
+	const minimumDevEngineObject = {
+		name: "node",
+	};
+
+	it.each([
+		{ description: "an empty object", value: {} },
+		{
+			description: "a valid devEngines with all objects",
+			value: {
+				cpu: minimumDevEngineObject,
+				libc: minimumDevEngineObject,
+				os: minimumDevEngineObject,
+				packageManager: partialDevEngineObject,
+				runtime: completeDevEngineObject,
+			},
+		},
+		{
+			description: "a valid devEngines with arrays",
+			value: { runtime: [completeDevEngineObject, partialDevEngineObject] },
+		},
+	])("should not return any issues for $description", ({ value }) => {
+		const result = validateDevEngines(value);
+		expect(result.issues).toHaveLength(0);
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it.each([
+		{ description: "Array", value: [] },
+		{ description: "boolean", value: true },
+		{ description: "number", value: 123 },
+		{ description: "string", value: "test" },
+	])(
+		"should return an issue if the value is not an object (%description)",
+		({ description, value }) => {
+			const result = validateDevEngines(value);
+			expect(result.issues).toHaveLength(1);
+			expect(result.errorMessages).toEqual([
+				`the value should be an \`object\`, not \`${description}\``,
+			]);
+		},
+	);
+
+	it("should return an issue if the value is not an object (null)", () => {
+		const result = validateDevEngines(null);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be an `object`",
+		]);
+	});
+
+	it("should return an issue if the value has unexpected properties", () => {
+		const mockBadDevEnginesObject = {
+			invalid: completeDevEngineObject,
+		};
+		const result = validateDevEngines(mockBadDevEnginesObject);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(1);
+		expect(result.childResults[0].issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"unexpected property `invalid`; only the following properties are allowed: cpu, libc, os, packageManager, runtime",
+		]);
+	});
+
+	it("should return issues if a devEngine object is missing the required `name` property", () => {
+		const mockBadDevEnginesObject = {
+			runtime: {
+				onFail: "warn",
+				version: "^20.19.0 || >=22.12.0",
+			},
+		};
+		const result = validateDevEngines(mockBadDevEnginesObject);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(1);
+		expect(result.childResults[0].issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"missing required property `name` in devEngine object",
+		]);
+	});
+
+	it("should return issues if a devEngine object has extra properties", () => {
+		const mockBadDevEnginesObject = {
+			runtime: {
+				invalid: "value",
+				name: "some name",
+				onFail: "warn",
+				version: "^20.19.0 || >=22.12.0",
+			},
+		};
+		const result = validateDevEngines(mockBadDevEnginesObject);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(1);
+		expect(result.childResults[0].issues).toHaveLength(0);
+		expect(result.childResults[0].childResults).toHaveLength(4);
+		expect(result.childResults[0].childResults[0].issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"unexpected property `invalid`; only `name`, `version`, and `onFail` are allowed in a devEngine object",
+		]);
+	});
+
+	it("should return an issue if the top-level property value is not of the correct type", () => {
+		const mockBadDevEnginesObject = {
+			runtime: 123,
+		};
+		const result = validateDevEngines(mockBadDevEnginesObject);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(1);
+		expect(result.childResults[0].issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the value should be an object with at least `name` and optionally `version` and `onFail`, not `number`",
+		]);
+	});
+
+	it("should return an issue if the nested property value is an array", () => {
+		const mockBadDevEnginesObject = {
+			runtime: [[completeDevEngineObject]],
+		};
+		const result = validateDevEngines(mockBadDevEnginesObject);
+		expect(result.childResults).toHaveLength(1);
+		expect(result.childResults[0].childResults).toHaveLength(1);
+		expect(result.childResults[0].childResults[0].issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the value should be an object with at least `name` and optionally `version` and `onFail`, not `Array`",
+		]);
+	});
+
+	it("should return issues if the nested devEngine object has invalid values (number)", () => {
+		const mockBadDevEnginesObject = {
+			runtime: {
+				name: 123,
+				onFail: 123,
+				version: 123,
+			},
+		};
+		const result = validateDevEngines(mockBadDevEnginesObject);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(1);
+		expect(result.childResults[0].issues).toHaveLength(0);
+		expect(result.childResults[0].childResults).toHaveLength(3);
+		expect(result.childResults[0].childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[0].childResults[1].issues).toHaveLength(1);
+		expect(result.childResults[0].childResults[2].issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the `name` property should be a string, but got `number`",
+			"the `onFail` property should be a string, but got `number`",
+			"the `version` property should be a string, but got `number`",
+		]);
+	});
+
+	it("should return issues if the nested devEngine object has invalid values (Array)", () => {
+		const mockBadDevEnginesObject = {
+			runtime: {
+				name: [],
+				onFail: [],
+				version: [],
+			},
+		};
+		const result = validateDevEngines(mockBadDevEnginesObject);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(1);
+		expect(result.childResults[0].issues).toHaveLength(0);
+		expect(result.childResults[0].childResults).toHaveLength(3);
+		expect(result.childResults[0].childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[0].childResults[1].issues).toHaveLength(1);
+		expect(result.childResults[0].childResults[2].issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the `name` property should be a string, but got `Array`",
+			"the `onFail` property should be a string, but got `Array`",
+			"the `version` property should be a string, but got `Array`",
+		]);
+	});
+
+	it("should return issues if the nested devEngine object has invalid values (null)", () => {
+		const mockBadDevEnginesObject = {
+			runtime: {
+				name: null,
+				onFail: null,
+				version: null,
+			},
+		};
+		const result = validateDevEngines(mockBadDevEnginesObject);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(1);
+		expect(result.childResults[0].issues).toHaveLength(0);
+		expect(result.childResults[0].childResults).toHaveLength(3);
+		expect(result.childResults[0].childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[0].childResults[1].issues).toHaveLength(1);
+		expect(result.childResults[0].childResults[2].issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the `name` property should be a string, but got `null`",
+			"the `onFail` property should be a string, but got `null`",
+			"the `version` property should be a string, but got `null`",
+		]);
+	});
+
+	it("should return issues if the nested devEngine object has invalid onFail value", () => {
+		const mockBadDevEnginesObject = {
+			runtime: {
+				name: "node",
+				onFail: "invalid",
+			},
+		};
+		const result = validateDevEngines(mockBadDevEnginesObject);
+		expect(result.childResults[0].childResults[0].issues).toHaveLength(0);
+		expect(result.childResults[0].childResults[1].issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the `onFail` property should be one of the following values: warn, error, ignore, download",
+		]);
+	});
+
+	it("should return issues if the nested devEngine object has empty name and version values", () => {
+		const mockBadDevEnginesObject = {
+			runtime: {
+				name: "",
+				version: "",
+			},
+		};
+		const result = validateDevEngines(mockBadDevEnginesObject);
+		expect(result.childResults[0].childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[0].childResults[1].issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the `name` property should not be empty",
+			"the `version` property should not be empty",
+		]);
+	});
+});

--- a/src/validators/validateDevEngines.ts
+++ b/src/validators/validateDevEngines.ts
@@ -1,0 +1,169 @@
+import { Result } from "../Result.ts";
+import { isPlainObject } from "../utils/index.ts";
+
+const devEngineProperties = ["cpu", "libc", "os", "packageManager", "runtime"];
+const validDevEngineObjectProperties = ["name", "version", "onFail"];
+const validOnFailValues = ["warn", "error", "ignore", "download"];
+
+/**
+ * Validates an individual devEngine object, which should have the following properties:
+ * - `name` (required): the name of the engine, e.g. "node", "npm", "yarn", "bun"
+ * - `version` (optional): the version of the engine, which should be a valid semver range
+ * - `onFail` (optional): should be one of the following values: `warn`, `error`, `ignore` or `download`
+ * @example
+ * {
+ *   "name": "node",
+ *   "version": "^20.19.0 || >=22.12.0",
+ *   "onFail": "download"
+ * }
+ */
+const validateDevEngineObject = (value: unknown): Result => {
+	const result = new Result();
+
+	if (isPlainObject(value)) {
+		const keys = Object.keys(value);
+		for (let i = 0; i < keys.length; i++) {
+			const key = keys[i];
+			const childResult = new Result();
+			if (!validDevEngineObjectProperties.includes(key)) {
+				childResult.addIssue(
+					`unexpected property \`${key}\`; only \`name\`, \`version\`, and \`onFail\` are allowed in a devEngine object`,
+				);
+			}
+			if (key === "name") {
+				if (typeof value[key] !== "string") {
+					const valueType =
+						value[key] === null
+							? "null"
+							: Array.isArray(value[key])
+								? "Array"
+								: typeof value[key];
+					childResult.addIssue(
+						`the \`name\` property should be a string, but got \`${valueType}\``,
+					);
+				} else if (value[key].trim() === "") {
+					childResult.addIssue("the `name` property should not be empty");
+				}
+			}
+			if (key === "onFail") {
+				if (typeof value[key] !== "string") {
+					const valueType =
+						value[key] === null
+							? "null"
+							: Array.isArray(value[key])
+								? "Array"
+								: typeof value[key];
+					childResult.addIssue(
+						`the \`onFail\` property should be a string, but got \`${valueType}\``,
+					);
+				} else if (!validOnFailValues.includes(value[key])) {
+					childResult.addIssue(
+						`the \`onFail\` property should be one of the following values: ${validOnFailValues.join(", ")}`,
+					);
+				}
+			}
+			if (key === "version") {
+				if (typeof value[key] !== "string") {
+					const valueType =
+						value[key] === null
+							? "null"
+							: Array.isArray(value[key])
+								? "Array"
+								: typeof value[key];
+					childResult.addIssue(
+						`the \`version\` property should be a string, but got \`${valueType}\``,
+					);
+				} else if (value[key].trim() === "") {
+					childResult.addIssue("the `version` property should not be empty");
+				}
+			}
+			result.addChildResult(i, childResult);
+		}
+		if (!keys.includes("name")) {
+			result.addIssue("missing required property `name` in devEngine object");
+		}
+	} else {
+		const valueType = Array.isArray(value) ? "Array" : typeof value;
+		result.addIssue(
+			`the value should be an object with at least \`name\` and optionally \`version\` and \`onFail\`, not \`${valueType}\``,
+		);
+	}
+	return result;
+};
+
+/**
+ * Validates an entry in the `devEngines` objects, which can either be an array
+ * of devEngine objects, or a single devEngine object.
+ */
+const validateDevEngineArrayOrObject = (value: unknown): Result => {
+	let result;
+	if (Array.isArray(value)) {
+		result = new Result();
+		for (let i = 0; i < value.length; i++) {
+			const itemResult = validateDevEngineObject(value[i]);
+			result.addChildResult(i, itemResult);
+		}
+	} else {
+		result = validateDevEngineObject(value);
+	}
+	return result;
+};
+
+/**
+ * Validates the `devEngines` field in a package.json, which should be an object
+ * with any of the following properties:
+ * - `cpu`
+ * - `libc`
+ * - `os`
+ * - `packageManager`
+ * - `runtime`
+ *
+ * The value of each property should be an object or an array objects with
+ * the following properties:
+ * - `name` (required): the name of the engine, e.g. "node", "npm", "yarn", "bun"
+ * - `version` (optional): the version of the engine, which should be a valid semver range
+ * - `onFail` (optional): should be one of the following values: `warn`, `error`, `ignore` or `download`
+ * @example
+ * "devEngines": {
+ *   "runtime": {
+ *     "name": "node",
+ *     "version": "^20.19.0 || >=22.12.0",
+ *     "onFail": "download"
+ *   },
+ *   "packageManager": {
+ *     "name": "pnpm",
+ *     "version": "^10.0.0",
+ *     "onFail": "error"
+ *   }
+ * }
+ * @see https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines
+ * @see https://pnpm.io/package_json#devenginesruntime
+ */
+export const validateDevEngines = (value: unknown): Result => {
+	const result = new Result();
+
+	if (isPlainObject(value)) {
+		const keys = Object.keys(value);
+		for (let i = 0; i < keys.length; i++) {
+			let childResult: Result;
+			const key = keys[i];
+
+			if (devEngineProperties.includes(key)) {
+				childResult = validateDevEngineArrayOrObject(value[key]);
+			} else {
+				childResult = new Result([
+					`unexpected property \`${key}\`; only the following properties are allowed: ${devEngineProperties.join(", ")}`,
+				]);
+			}
+
+			result.addChildResult(i, childResult);
+		}
+	} else if (value === null) {
+		result.addIssue("the value is `null`, but should be an `object`");
+	} else {
+		const valueType = Array.isArray(value) ? "Array" : typeof value;
+		result.addIssue(`the value should be an \`object\`, not \`${valueType}\``);
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #741
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateDevEngines` function.  It checks that the value against the following criteria:

- it should be an `object` with any of the following properties
  - `cpu`
  - `libc`
  - `os`
  - `packageManager`
  - `runtime`
- The value of each property should be an object or an Array of objects with the following properties
  - `name` (required): the name of the engine, e.g. "node", "npm", "yarn", "bun"
  - `version` (optional): the version of the engine, which should be a valid semver range
  - `onFail` (optional): should be one of the following values: `warn`, `error`, `ignore` or `download`
