### PR TITLE
fix: handle null values for top-level devEngines properties correctly

### DIFF
--- a/src/validators/validateDevEngines.test.ts
+++ b/src/validators/validateDevEngines.test.ts
@@ -113,13 +113,16 @@ describe(validateDevEngines, () => {
 
 	it("should return an issue if the top-level property value is not of the correct type", () => {
 		const mockBadDevEnginesObject = {
+			packageManager: null,
 			runtime: 123,
 		};
 		const result = validateDevEngines(mockBadDevEnginesObject);
 		expect(result.issues).toHaveLength(0);
-		expect(result.childResults).toHaveLength(1);
+		expect(result.childResults).toHaveLength(2);
 		expect(result.childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[1].issues).toHaveLength(1);
 		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be an object with at least `name` and optionally `version` and `onFail`",
 			"the value should be an object with at least `name` and optionally `version` and `onFail`, not `number`",
 		]);
 	});

--- a/src/validators/validateDevEngines.ts
+++ b/src/validators/validateDevEngines.ts
@@ -82,6 +82,10 @@ const validateDevEngineObject = (value: unknown): Result => {
 		if (!keys.includes("name")) {
 			result.addIssue("missing required property `name` in devEngine object");
 		}
+	} else if (value === null) {
+		result.addIssue(
+			"the value is `null`, but should be an object with at least `name` and optionally `version` and `onFail`",
+		);
 	} else {
 		const valueType = Array.isArray(value) ? "Array" : typeof value;
 		result.addIssue(


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

We didn't communicate null values properly for nested values in the devEngines object.  This fixes it
