### PR TITLE
ci: add condition for ci label event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,18 +8,9 @@ on:
       - main
 
 jobs:
-  # Gatekeeper job to ensure that if ci ran because of a label event, we're only running if the label is "ci"
-  check_trigger:
-    name: Check Trigger
-    if: github.event.action != 'labeled' || github.event.label.name == 'ci'
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Trigger condition met, proceeding with CI..."
-
-  # Actual CI jobs
   build:
     name: Build
-    needs: check_trigger
+    if: github.event.action != 'labeled' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -29,7 +20,7 @@ jobs:
 
   dedupe_check:
     name: Dedupe Check
-    needs: check_trigger
+    if: github.event.action != 'labeled' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -38,7 +29,7 @@ jobs:
 
   lint:
     name: Lint
-    needs: check_trigger
+    if: github.event.action != 'labeled' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -48,7 +39,7 @@ jobs:
 
   lint_knip:
     name: Lint Knip
-    needs: check_trigger
+    if: github.event.action != 'labeled' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -57,7 +48,7 @@ jobs:
 
   prettier:
     name: Prettier
-    needs: check_trigger
+    if: github.event.action != 'labeled' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -66,7 +57,7 @@ jobs:
 
   test:
     name: Test
-    needs: check_trigger
+    if: github.event.action != 'labeled' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -79,7 +70,7 @@ jobs:
 
   type_check:
     name: Type Check
-    needs: check_trigger
+    if: github.event.action != 'labeled' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,45 +8,65 @@ on:
       - main
 
 jobs:
+  # Gatekeeper job to ensure that if ci ran because of a label event, we're only running if the label is "ci"
+  check_trigger:
+    name: Check Trigger
+    if: github.event.action != 'labeled' || github.event.label.name == 'ci'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Trigger condition met, proceeding with CI..."
+
+  # Actual CI jobs
   build:
     name: Build
+    needs: check_trigger
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/prepare
       - run: pnpm build
       - run: node lib/index.mjs
+
   dedupe_check:
     name: Dedupe Check
+    needs: check_trigger
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/prepare
       - run: pnpm dedupe --check --prefer-offline
+
   lint:
     name: Lint
+    needs: check_trigger
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/prepare
       - run: pnpm build
       - run: pnpm lint
+
   lint_knip:
     name: Lint Knip
+    needs: check_trigger
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/prepare
       - run: pnpm lint:knip
+
   prettier:
     name: Prettier
+    needs: check_trigger
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/prepare
       - run: pnpm format --list-different
+
   test:
     name: Test
+    needs: check_trigger
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -56,8 +76,10 @@ jobs:
         if: always()
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   type_check:
     name: Type Check
+    needs: check_trigger
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change makes it so that the labeled trigger is only acted upon when the label that was added is "ci"
